### PR TITLE
discover command

### DIFF
--- a/pkg/cmd/modules.go
+++ b/pkg/cmd/modules.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	_ "github.com/manusa/ai-cli/pkg/feature/fs"
 	_ "github.com/manusa/ai-cli/pkg/inference/gemini"
 	_ "github.com/manusa/ai-cli/pkg/inference/ollama"
 )

--- a/pkg/feature/discover.go
+++ b/pkg/feature/discover.go
@@ -1,0 +1,46 @@
+package feature
+
+import (
+	"fmt"
+
+	"github.com/manusa/ai-cli/pkg/config"
+)
+
+var providers = map[string]FeatureProvider{}
+
+type FeatureAttributes struct {
+	Name string
+}
+
+type FeatureProvider interface {
+	Attributes() FeatureAttributes
+	IsAvailable(cfg *config.Config) bool
+}
+
+type Feature struct {
+	FeatureAttributes
+}
+
+// Register a new feature provider
+func Register(provider FeatureProvider) {
+	if _, ok := providers[provider.Attributes().Name]; ok {
+		panic(fmt.Sprintf("feature provider already registered: %s", provider.Attributes().Name))
+	}
+	providers[provider.Attributes().Name] = provider
+}
+
+// cleanup for tests
+//func cleanup() {
+//	providers = map[string]FeatureProvider{}
+//}
+
+// getAvailableModels gets all available models from all providers
+func GetAvailableFeatures(cfg *config.Config) ([]FeatureAttributes, error) {
+	features := []FeatureAttributes{}
+	for _, provider := range providers {
+		if provider.IsAvailable(cfg) {
+			features = append(features, provider.Attributes())
+		}
+	}
+	return features, nil
+}

--- a/pkg/feature/fs/fs.go
+++ b/pkg/feature/fs/fs.go
@@ -1,0 +1,24 @@
+package fs
+
+import (
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/manusa/ai-cli/pkg/feature"
+)
+
+type FSProvider struct{}
+
+var fsProvider = FSProvider{}
+
+func init() {
+	feature.Register(fsProvider)
+}
+
+func (o FSProvider) Attributes() feature.FeatureAttributes {
+	return feature.FeatureAttributes{
+		Name: "fs",
+	}
+}
+
+func (o FSProvider) IsAvailable(cfg *config.Config) bool {
+	return true
+}


### PR DESCRIPTION
- adds a `discover` command to display the discovered features and inference servers

```
$ GEMINI_API_KEY=ABCDEF ./ai-cli discover
available inferences:
  - ollama
  - gemini

available features:
  - fs
```

The inference part will help the user choose an explicit inference (see https://github.com/manusa/ai-cli/issues/10)

The feature part is in a very early stage