### PR TITLE
feat: discover models for each inference server

### DIFF
--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"strings"
+
 	"github.com/manusa/ai-cli/pkg/config"
 	"github.com/manusa/ai-cli/pkg/features"
 	"github.com/spf13/cobra"
@@ -72,6 +75,11 @@ func (o *DiscoverCmdOptions) Run(cmd *cobra.Command) error {
 		_, _ = fmt.Printf("Available Inference Providers:\n")
 		for _, provider := range discoveredFeatures.Inferences {
 			fmt.Printf("  - %s\n", provider.Attributes().Name())
+			models, err := provider.GetModels(context.Background(), config.New())
+			if err != nil {
+				fmt.Printf("    (error getting models: %v)\n", err)
+			}
+			fmt.Printf("    Models:\n    - %s\n", strings.Join(models, "\n    - "))
 		}
 		_, _ = fmt.Printf("Selected Inference Provider: %s\n", discoveredFeatures.Inferences[0].Attributes().Name())
 		_, _ = fmt.Printf("Available Tools Providers:\n")

--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -2,11 +2,12 @@ package features
 
 import (
 	"context"
+	"testing"
+
 	"github.com/manusa/ai-cli/pkg/api"
 	"github.com/manusa/ai-cli/pkg/inference"
 	"github.com/manusa/ai-cli/pkg/tools"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/cloudwego/eino/components/model"
 	"github.com/manusa/ai-cli/pkg/config"
@@ -46,6 +47,10 @@ func (t *InferenceProvider) Attributes() inference.Attributes {
 			FeatureName: t.Name,
 		},
 	}
+}
+
+func (t *InferenceProvider) GetModels(_ context.Context, _ *config.Config) ([]string, error) {
+	return []string{}, nil
 }
 
 func (t *InferenceProvider) IsAvailable(_ *config.Config) bool {

--- a/pkg/inference/discover.go
+++ b/pkg/inference/discover.go
@@ -19,6 +19,7 @@ type Attributes struct {
 
 type Provider interface {
 	api.Feature[Attributes]
+	GetModels(ctx context.Context, cfg *config.Config) ([]string, error)
 	GetInference(ctx context.Context, cfg *config.Config) (model.ToolCallingChatModel, error)
 }
 

--- a/pkg/inference/discover_test.go
+++ b/pkg/inference/discover_test.go
@@ -29,6 +29,10 @@ func (t *TestProvider) IsAvailable(_ *config.Config) bool {
 	return t.Available
 }
 
+func (t *TestProvider) GetModels(_ context.Context, _ *config.Config) ([]string, error) {
+	return []string{}, nil
+}
+
 func (t *TestProvider) GetInference(_ context.Context, _ *config.Config) (model.ToolCallingChatModel, error) {
 	return nil, nil
 }

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -29,6 +29,10 @@ func (geminiProvider *Provider) IsAvailable(cfg *config.Config) bool {
 	return cfg.GoogleApiKey != ""
 }
 
+func (geminiProvider *Provider) GetModels(ctx context.Context, cfg *config.Config) ([]string, error) {
+	return []string{"gemini-2.0-flash"}, nil
+}
+
 func (geminiProvider *Provider) GetInference(ctx context.Context, cfg *config.Config) (model.ToolCallingChatModel, error) {
 	geminiCli, err := genai.NewClient(ctx, &genai.ClientConfig{
 		APIKey: cfg.GoogleApiKey,

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -2,6 +2,8 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/cloudwego/eino-ext/components/model/ollama"
@@ -17,6 +19,13 @@ type Provider struct{}
 
 var _ inference.Provider = &Provider{}
 
+// ModelsList is the response from the /v1/models endpoint
+type ModelsList struct {
+	Data []struct {
+		Id string `json:"id"`
+	} `json:"data"`
+}
+
 func (ollamaProvider *Provider) Attributes() inference.Attributes {
 	return inference.Attributes{
 		BasicFeatureAttributes: api.BasicFeatureAttributes{
@@ -24,6 +33,27 @@ func (ollamaProvider *Provider) Attributes() inference.Attributes {
 		},
 		Distant: false,
 	}
+}
+
+func (ollamaProvider *Provider) GetModels(ctx context.Context, cfg *config.Config) ([]string, error) {
+	resp, err := http.Get(baseURL + "/v1/models")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	modelsList := ModelsList{}
+	if err = json.Unmarshal(body, &modelsList); err != nil {
+		return nil, err
+	}
+	modelsNames := make([]string, len(modelsList.Data))
+	for i, model := range modelsList.Data {
+		modelsNames[i] = model.Id
+	}
+	return modelsNames, nil
 }
 
 func (ollamaProvider *Provider) IsAvailable(cfg *config.Config) bool {


### PR DESCRIPTION
Output example:

```
GEMINI_API_KEY=ABCDEF ./ai-cli discover -o text
Available Inference Providers:
  - ollama
    Models:
    - all-minilm:latest
    - mistral:7b
    - llama3.2:3b
    - llama3.2:3b-instruct-fp16
    - llama3:latest
    - firefunction-v2:latest
  - gemini
    Models:
    - gemini-2.0-flash
Selected Inference Provider: ollama
Available Tools Providers:
  - fs
```

The ollama models list is obtained from the `/v1/models` endpoint.

The gemini list is hardcoded 