### PR TITLE
feat: change Distant to Local and add Public

### DIFF
--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -151,7 +151,7 @@ func TestDiscoverMarshal(t *testing.T) {
 			assert.Nil(t, err, "expected no error when marshalling inferences")
 		})
 		t.Run("Marshalling returns expected JSON", func(t *testing.T) {
-			assert.JSONEq(t, `{"inference":{"name":"gemini","distant":true},"inferences":[{"name":"gemini","distant":true}],"tools":[{"name":"fs"}]}`,
+			assert.JSONEq(t, `{"inference":{"local":false,"name":"gemini","public":true},"inferences":[{"local":false,"name":"gemini","public":true}],"tools":[{"name":"fs"}]}`,
 				string(bytes),
 				"expected JSON to match the expected format")
 		})

--- a/pkg/inference/discover.go
+++ b/pkg/inference/discover.go
@@ -16,7 +16,8 @@ var providers = map[string]Provider{}
 type Attributes struct {
 	api.BasicFeatureAttributes
 	// TODO: maybe rename to local or remote
-	Distant bool `json:"distant"` // Indicates if the inference provider is a remote service or a local one
+	Local  bool `json:"local"`  // Indicates if the inference provider is a local service
+	Public bool `json:"public"` // Indicates if the inference provider is public (e.g. OpenAI, Gemini) or private (e.g. Enterprise internal)
 }
 
 type Provider interface {

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -23,7 +23,8 @@ func (geminiProvider *Provider) Attributes() inference.Attributes {
 		BasicFeatureAttributes: api.BasicFeatureAttributes{
 			FeatureName: "gemini",
 		},
-		Distant: true,
+		Local:  false,
+		Public: true,
 	}
 }
 

--- a/pkg/inference/gemini/gemini_test.go
+++ b/pkg/inference/gemini/gemini_test.go
@@ -1,8 +1,9 @@
 package gemini
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -12,6 +13,6 @@ func TestMarshalJSON(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("MarshalJSON returns expected JSON", func(t *testing.T) {
-		assert.JSONEq(t, `{"name":"gemini","distant":true}`, string(data))
+		assert.JSONEq(t, `{"local":false,"name":"gemini","public":true}`, string(data))
 	})
 }

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -32,7 +32,8 @@ func (ollamaProvider *Provider) Attributes() inference.Attributes {
 		BasicFeatureAttributes: api.BasicFeatureAttributes{
 			FeatureName: "ollama",
 		},
-		Distant: false,
+		Local:  true,
+		Public: false,
 	}
 }
 

--- a/pkg/inference/ollama/ollama_test.go
+++ b/pkg/inference/ollama/ollama_test.go
@@ -1,8 +1,9 @@
 package ollama
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -12,6 +13,6 @@ func TestMarshalJSON(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("MarshalJSON returns expected JSON", func(t *testing.T) {
-		assert.JSONEq(t, `{"name":"ollama","distant":false}`, string(data))
+		assert.JSONEq(t, `{"local":true,"name":"ollama","public":false}`, string(data))
 	})
 }


### PR DESCRIPTION
In the Inference attributes:
- change Distant to Local
- add Public


The text output does not display these attributes for now. The text output will be improved in follow-up PR(s)
