### PR TITLE
feat: tools can get help of models to be discovered

### DIFF
--- a/pkg/api/features.go
+++ b/pkg/api/features.go
@@ -27,3 +27,8 @@ func (b BasicFeatureAttributes) Name() string {
 type BasicFeatureData struct {
 	Reason string `json:"reason"`
 }
+
+type ModelAttributes struct {
+	NeededTools []string
+	Prompt      string
+}

--- a/pkg/cmd/chat.go
+++ b/pkg/cmd/chat.go
@@ -85,7 +85,7 @@ func (o *ChatCmdOptions) Run(cmd *cobra.Command) error {
 		cfg.Model = &o.model
 	}
 
-	availableFeatures := features.Discover(cfg)
+	availableFeatures := features.Discover(cmd.Context(), cfg)
 	if availableFeatures.Inference == nil {
 		return fmt.Errorf("no suitable inference found")
 	}

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -60,8 +60,8 @@ func (o *DiscoverCmdOptions) Validate() error {
 }
 
 // Run executes the main logic of the command once its complete and validated
-func (o *DiscoverCmdOptions) Run(_ *cobra.Command) error {
-	discoveredFeatures := features.Discover(config.New())
+func (o *DiscoverCmdOptions) Run(cmd *cobra.Command) error {
+	discoveredFeatures := features.Discover(cmd.Context(), config.New())
 	// TODO: maybe create an output package to handle different output formats globally
 	switch o.outputFormat {
 	case "json":

--- a/pkg/cmd/modules.go
+++ b/pkg/cmd/modules.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	_ "github.com/manusa/ai-cli/pkg/inference/gemini"
 	_ "github.com/manusa/ai-cli/pkg/inference/ollama"
+	_ "github.com/manusa/ai-cli/pkg/tools/chrome-history"
 	_ "github.com/manusa/ai-cli/pkg/tools/fs"
 	_ "github.com/manusa/ai-cli/pkg/tools/kubernetes"
+	_ "github.com/manusa/ai-cli/pkg/tools/os"
 )

--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -81,7 +81,7 @@ func TestDiscoverInference(t *testing.T) {
 	testCase(t, func(c *testContext) {
 		inference.Register(&InferenceProvider{Name: "availableProvider", Available: true})
 		inference.Register(&InferenceProvider{Name: "unavailableProvider", Available: false})
-		features := Discover(config.New())
+		features := Discover(context.Background(), config.New())
 		t.Run("With one available provider returns features", func(t *testing.T) {
 			assert.NotNil(t, features, "expected an inference to be returned")
 		})
@@ -106,7 +106,7 @@ func TestDiscoverKnownExplicitInference(t *testing.T) {
 		cfg.Inference = func(s string) *string {
 			return &s
 		}("availableProvider")
-		features := Discover(cfg)
+		features := Discover(context.Background(), cfg)
 		t.Run("With one available provider returns features", func(t *testing.T) {
 			assert.NotNil(t, features, "expected an inference to be returned")
 		})
@@ -131,7 +131,7 @@ func TestDiscoverUnknownExplicitInference(t *testing.T) {
 		cfg.Inference = func(s string) *string {
 			return &s
 		}("otherProvider")
-		features := Discover(cfg)
+		features := Discover(context.Background(), cfg)
 		t.Run("With one available provider returns features", func(t *testing.T) {
 			assert.NotNil(t, features, "expected an inference to be returned")
 		})
@@ -154,7 +154,7 @@ func TestDiscoverMarshal(t *testing.T) {
 		inference.Register(&gemini.Provider{})
 		inference.Register(&ollama.Provider{})
 		tools.Register(&fs.Provider{})
-		features := Discover(config.New())
+		features := Discover(context.Background(), config.New())
 		bytes, err := json.Marshal(features)
 		t.Run("Marshalling returns no error", func(t *testing.T) {
 			assert.Nil(t, err, "expected no error when marshalling inferences")

--- a/pkg/tools/chrome-history/chrome-history.go
+++ b/pkg/tools/chrome-history/chrome-history.go
@@ -1,0 +1,61 @@
+package chrome
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/manusa/ai-cli/pkg/tools"
+)
+
+type Provider struct {
+	tools.BasicToolsProvider
+}
+
+var _ tools.Provider = &Provider{}
+
+func (p *Provider) Attributes() tools.Attributes {
+	return tools.Attributes{
+		BasicFeatureAttributes: api.BasicFeatureAttributes{
+			FeatureName: "chrome-history",
+		},
+		ModelAttributes: &api.ModelAttributes{
+			NeededTools: []string{"fs", "os"},
+			Prompt: `If my system is Windows, is the file 'History' exists in the directory 'AppData/Local/Google/Chrome/UserData/Default' in the home directory?
+Or if my system is Darwin, is the file 'History' exists in the directory 'Library/Application Support/Google/Chrome/Default' in the home directory?
+Or if the system is Linux, is the file 'History' exists in the directory '.config/google-chrome/Default' in the home directory?
+You can use tools without asking confirmation. If Yes, you must reply with Yes only. If No, explain why`,
+		},
+	}
+}
+
+func (p *Provider) IsAvailable(_ *config.Config) bool {
+	// not use, because ModelAttributes takes precedence
+	return false
+}
+
+func (p *Provider) Data() tools.Data {
+	return tools.Data{
+		BasicFeatureData: api.BasicFeatureData{
+			Reason: p.Reason,
+		},
+	}
+}
+
+func (p *Provider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
+	return []*api.Tool{}, nil
+}
+
+func (p *Provider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(tools.Report{
+		Attributes: p.Attributes(),
+		Data:       p.Data(),
+	})
+}
+
+var instance = &Provider{}
+
+func init() {
+	tools.Register(instance)
+}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/cloudwego/eino/components/model"
+	"github.com/manusa/ai-cli/pkg/ai"
 	"github.com/manusa/ai-cli/pkg/api"
 	"github.com/manusa/ai-cli/pkg/config"
 )
@@ -16,8 +18,13 @@ type BasicToolsProvider struct {
 	api.BasicFeatureProvider
 }
 
+func (p *BasicToolsProvider) SetReason(reason string) {
+	p.Reason = reason
+}
+
 type Attributes struct {
 	api.BasicFeatureAttributes
+	*api.ModelAttributes
 }
 
 type Data struct {
@@ -33,6 +40,7 @@ type Provider interface {
 	api.Feature[Attributes, Data]
 	GetTools(ctx context.Context, cfg *config.Config) ([]*api.Tool, error)
 	MarshalJSON() ([]byte, error)
+	SetReason(reason string)
 }
 
 // Register a new tools provider
@@ -51,9 +59,74 @@ func Clear() {
 // Discover the available tools based on the user preferences
 func Discover(cfg *config.Config) (availableTools []Provider, notAvailableTools []Provider) {
 	for _, provider := range providers {
+		if provider.Attributes().ModelAttributes != nil {
+			continue
+		}
 		if provider.IsAvailable(cfg) {
 			availableTools = append(availableTools, provider)
 		} else {
+			notAvailableTools = append(notAvailableTools, provider)
+		}
+	}
+	slices.SortFunc(availableTools, func(a, b Provider) int {
+		return strings.Compare(a.Attributes().Name(), b.Attributes().Name())
+	})
+	slices.SortFunc(notAvailableTools, func(a, b Provider) int {
+		return strings.Compare(a.Attributes().Name(), b.Attributes().Name())
+	})
+	return availableTools, notAvailableTools
+}
+
+func DiscoverWithModel(ctx context.Context, cfg *config.Config, llm model.ToolCallingChatModel, tools []Provider) (availableTools []Provider, notAvailableTools []Provider) {
+nextProvider:
+	for _, provider := range providers {
+		if provider.Attributes().ModelAttributes == nil {
+			continue
+		}
+		var allTools []*api.Tool
+
+		availableToolsNames := []string{}
+		for _, toolProvider := range tools {
+			availableToolsNames = append(availableToolsNames, toolProvider.Attributes().Name())
+		}
+
+		// Check that all needed tools are available
+		for _, neededTool := range provider.Attributes().NeededTools {
+			if !slices.Contains(availableToolsNames, neededTool) {
+				provider.SetReason(fmt.Sprintf("The necessary tool '%s' is not available", neededTool))
+				notAvailableTools = append(notAvailableTools, provider)
+				continue nextProvider
+			}
+		}
+
+		for _, toolProvider := range tools {
+			if !slices.Contains(provider.Attributes().NeededTools, toolProvider.Attributes().Name()) {
+				continue
+			}
+			tools, err := toolProvider.GetTools(ctx, cfg)
+			if err != nil {
+				continue
+			}
+			allTools = append(allTools, tools...)
+		}
+		aiAgent := ai.New(llm, allTools, cfg)
+		if err := aiAgent.Run(ctx); err != nil {
+			return nil, nil
+		}
+		aiAgent.Input <- api.NewUserMessage(provider.Attributes().Prompt)
+		for {
+			<-aiAgent.Output
+			if !aiAgent.Session().IsRunning() {
+				break
+			}
+		}
+		messages := aiAgent.Session().Messages()
+		last := messages[len(messages)-1].Text
+		if strings.TrimSpace(last) == "Yes" {
+			provider.SetReason("model replied Yes to the prompt")
+			availableTools = append(availableTools, provider)
+		} else {
+			provider.SetReason(fmt.Sprintf("model response:'%s'", last))
 			notAvailableTools = append(notAvailableTools, provider)
 		}
 	}

--- a/pkg/tools/discover_test.go
+++ b/pkg/tools/discover_test.go
@@ -44,6 +44,10 @@ func (t *TestProvider) GetTools(_ context.Context, _ *config.Config) ([]*api.Too
 
 func (t *TestProvider) MarshalJSON() ([]byte, error) { return json.Marshal(t.Attributes()) }
 
+func (t *TestProvider) SetReason(reason string) {
+	t.Reason = reason
+}
+
 type testContext struct {
 }
 

--- a/pkg/tools/fs/fs.go
+++ b/pkg/tools/fs/fs.go
@@ -40,6 +40,7 @@ func (p *Provider) Data() tools.Data {
 func (p *Provider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
 	return []*api.Tool{
 		FileList,
+		HomeDirectory,
 	}, nil
 }
 
@@ -88,6 +89,16 @@ var FileList = &api.Tool{
 			return "", err
 		}
 		return string(fileNamesJSON), nil
+	},
+}
+
+var HomeDirectory = &api.Tool{
+	Name: "home_directory",
+	Description: "Get the home directory of the user." +
+		"Returns the absolute path of the directory.",
+	Parameters: map[string]api.ToolParameter{},
+	Function: func(args map[string]interface{}) (string, error) {
+		return os.UserHomeDir()
 	},
 }
 

--- a/pkg/tools/os/os.go
+++ b/pkg/tools/os/os.go
@@ -1,0 +1,67 @@
+package os
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/manusa/ai-cli/pkg/tools"
+)
+
+type Provider struct {
+	tools.BasicToolsProvider
+}
+
+var _ tools.Provider = &Provider{}
+
+func (p *Provider) Attributes() tools.Attributes {
+	return tools.Attributes{
+		BasicFeatureAttributes: api.BasicFeatureAttributes{
+			FeatureName: "os",
+		},
+	}
+}
+
+func (p *Provider) IsAvailable(_ *config.Config) bool {
+	p.Reason = "os is accessible"
+	return true
+}
+
+func (p *Provider) Data() tools.Data {
+	return tools.Data{
+		BasicFeatureData: api.BasicFeatureData{
+			Reason: p.Reason,
+		},
+	}
+}
+
+func (p *Provider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
+	return []*api.Tool{
+		GetOS,
+	}, nil
+}
+
+func (p *Provider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(tools.Report{
+		Attributes: p.Attributes(),
+		Data:       p.Data(),
+	})
+}
+
+var GetOS = &api.Tool{
+	Name: "get_os",
+	Description: "Returns the name of the operating system (OS) of the user." +
+		"Returns the name of the OS.",
+	Parameters: map[string]api.ToolParameter{},
+	Function: func(args map[string]interface{}) (string, error) {
+		return runtime.GOOS, nil
+	},
+}
+
+var instance = &Provider{}
+
+func init() {
+	tools.Register(instance)
+}


### PR DESCRIPTION
This is an experiment to define discoverable tools using a model's prompt.

These tools are checked only when a model is first discovered.

The configuration defining how the tool is discovered is text only (necessary tools and prompt), this may easily be moved to a configuration file.

Only the discover part is done, no tools are provided to the model for such discovered features.

```
% GEMINI_API_KEY=$(cat /path/to/my-gemini-api-key) ./ai-cli discover|json_pp
{
   "inference" : {
      "local" : false,
      "models" : [
         "gemini-2.0-flash"
      ],
      "name" : "gemini",
      "public" : true,
      "reason" : "GEMINI_API_KEY is set"
   },
   "inferences" : [
      {
         "local" : false,
         "models" : [
            "gemini-2.0-flash"
         ],
         "name" : "gemini",
         "public" : true,
         "reason" : "GEMINI_API_KEY is set"
      }
   ],
   "inferencesNotAvailable" : [
      {
         "local" : true,
         "models" : null,
         "name" : "ollama",
         "public" : false,
         "reason" : "http://localhost:11434 is not accessible"
      }
   ],
   "tools" : [
      {
         "name" : "fs",
         "reason" : "filesystem is accessible"
      },
      {
         "name" : "os",
         "reason" : "os is accessible"
      },
      {
         "NeededTools" : [
            "fs",
            "os"
         ],
         "Prompt" : "If my system is Windows, is the file 'History' exists in the directory 'AppData/Local/Google/Chrome/UserData/Default' in the home directory?\nOr if my system is Darwin, is the file 'History' exists in the directory 'Library/Application Support/Google/Chrome/Default' in the home directory?\nOr if the system is Linux, is the file 'History' exists in the directory '.config/google-chrome/Default' in the home directory?\nYou can use tools without asking confirmation. If Yes, you must reply with Yes only. If No, explain why",
         "name" : "chrome-history",
         "reason" : "model replied Yes to the prompt"
      }
   ]
}
```