### PR TITLE
feat: document how to start MCP server for tools

### DIFF
--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -1,6 +1,12 @@
 package api
 
-import "github.com/getkin/kin-openapi/openapi3"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
 
 type Tool struct {
 	Name        string
@@ -23,4 +29,49 @@ type ToolParameter struct {
 	Type        ToolParameterType
 	Description string
 	Required    bool
+}
+
+type McpType int
+
+const (
+	McpTypeStdio McpType = iota
+	McpTypeSse
+	McpTypeStreamableHttp
+)
+
+var McpTypes = [...]string{
+	"stdio",
+	"sse",
+	"http",
+}
+
+func (t *McpType) String() string {
+	return McpTypes[*t]
+}
+
+func (t *McpType) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + t.String() + `"`), nil
+}
+
+func (t *McpType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("unmarshaling McpType: %w", err)
+	}
+	for i, v := range McpTypes {
+		if strings.EqualFold(v, s) {
+			*t = McpType(i)
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid McpType: %s", s)
+}
+
+type McpSettings struct {
+	Type    McpType           `json:"type"`              // Type of MCP (STDIO, SSE, or HTTP)
+	Command string            `json:"command,omitempty"` // Command to run for STDIO type
+	Args    []string          `json:"args,omitempty"`    // Arguments for the command (STDIO)
+	Env     []string          `json:"env,omitempty"`     // Environment variables for the command (STDIO)
+	Url     string            `json:"url,omitempty"`     // URL for SSE or HTTP type
+	Headers map[string]string `json:"headers,omitempty"` // Headers for HTTP requests (SSE or HTTP)
 }

--- a/pkg/api/tools_test.go
+++ b/pkg/api/tools_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type McpTypeTestSuite struct {
+	suite.Suite
+}
+
+func (s *McpTypeTestSuite) TestString() {
+	cases := []struct {
+		Type     McpType
+		Expected string
+	}{
+		{McpTypeStdio, "stdio"},
+		{McpTypeSse, "sse"},
+		{McpTypeStreamableHttp, "http"},
+	}
+	for _, c := range cases {
+		s.Run(fmt.Sprintf("%v is converted to %s", c.Type, c.Expected), func() {
+			s.Equal(c.Expected, c.Type.String())
+		})
+	}
+}
+
+func (s *McpTypeTestSuite) TestMarshalJSON() {
+	cases := []struct {
+		Type     McpType
+		Expected string
+	}{
+		{McpTypeStdio, `["stdio"]`},
+		{McpTypeSse, `["sse"]`},
+		{McpTypeStreamableHttp, `["http"]`},
+	}
+	for _, c := range cases {
+		data, err := json.Marshal([]McpType{c.Type})
+		s.Run(fmt.Sprintf("Marshaling %v returns no error", c.Type), func() {
+			s.NoError(err, "Expected no error when marshaling McpType")
+		})
+		s.Run(fmt.Sprintf("%v is marshaled to %s", c.Type, c.Expected), func() {
+			s.Equal(c.Expected, string(data))
+		})
+	}
+}
+
+func (s *McpTypeTestSuite) TestUnmarshalJSON() {
+	cases := []struct {
+		Input    string
+		Expected McpType
+	}{
+		{`"stdio"`, McpTypeStdio},
+		{`"sse"`, McpTypeSse},
+		{`"http"`, McpTypeStreamableHttp},
+		{`"stdIO"`, McpTypeStdio},
+		{`"sSe"`, McpTypeSse},
+		{`"hTTp"`, McpTypeStreamableHttp},
+	}
+	for _, c := range cases {
+		var t McpType
+		err := json.Unmarshal([]byte(c.Input), &t)
+		s.Run(fmt.Sprintf("Unmarshaling %s returns no error", c.Input), func() {
+			s.NoError(err, "Expected no error when unmarshalling McpType")
+		})
+		s.Run(fmt.Sprintf("%s is unmarshalled to %v", c.Input, c.Expected), func() {
+			s.Equal(c.Expected, t)
+		})
+	}
+	s.Run("Unmarshalling invalid McpType returns error", func() {
+		var t []McpType
+		err := json.Unmarshal([]byte(`["invalid"]`), &t)
+		s.Error(err, "Expected error when unmarshalling invalid McpType")
+		s.Equal([]McpType{McpTypeStdio}, t, "Expected slice to contain default McpTypeStdio when unmarshalling invalid type")
+	})
+}
+
+func TestMcpType(t *testing.T) {
+	suite.Run(t, new(McpTypeTestSuite))
+}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -18,10 +18,16 @@ type BasicToolsProvider struct {
 
 type Attributes struct {
 	api.BasicFeatureAttributes
+	McpCommands []McpCommand `json:"mcp_commands,omitempty"`
 }
 
 type Data struct {
 	api.BasicFeatureData
+}
+
+type McpCommand struct {
+	Cmd  string   `json:"cmd"`
+	Args []string `json:"args"`
 }
 
 type Report struct {

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -18,16 +18,11 @@ type BasicToolsProvider struct {
 
 type Attributes struct {
 	api.BasicFeatureAttributes
-	McpCommands []McpCommand `json:"mcp_commands,omitempty"`
 }
 
 type Data struct {
 	api.BasicFeatureData
-}
-
-type McpCommand struct {
-	Cmd  string   `json:"cmd"`
-	Args []string `json:"args"`
+	McpSettings *api.McpSettings `json:"mcp_settings,omitempty"` // Settings for the MCP (Multi-Command Protocol) if applicable
 }
 
 type Report struct {

--- a/pkg/tools/kubernetes/kubernetes.go
+++ b/pkg/tools/kubernetes/kubernetes.go
@@ -30,6 +30,16 @@ const (
 var (
 	RecommendedConfigDir = filepath.Join(homedir(), RecommendedHomeDir)
 	RecommendedHomeFile  = filepath.Join(RecommendedConfigDir, RecommendedFileName)
+	mcpCommands          = []tools.McpCommand{
+		{
+			Cmd:  "npx",
+			Args: []string{"-y", "kubernetes-mcp-server@latest"},
+		},
+		{
+			Cmd:  "uvx",
+			Args: []string{"kubernetes-mcp-server@latest"},
+		},
+	}
 )
 
 func (p *Provider) Attributes() tools.Attributes {
@@ -37,6 +47,7 @@ func (p *Provider) Attributes() tools.Attributes {
 		BasicFeatureAttributes: api.BasicFeatureAttributes{
 			FeatureName: "kubernetes",
 		},
+		McpCommands: mcpCommands,
 	}
 }
 
@@ -162,10 +173,10 @@ func (p *Provider) MarshalJSON() ([]byte, error) {
 }
 
 func getBestMcpServerCommand() ([]string, error) {
-	if commandExists("npx") {
-		return []string{"npx", "-y", "kubernetes-mcp-server@latest"}, nil
-	} else if commandExists("uvx") {
-		return []string{"uvx", "kubernetes-mcp-server@latest"}, nil
+	for _, command := range mcpCommands {
+		if commandExists(command.Cmd) {
+			return append([]string{command.Cmd}, command.Args...), nil
+		}
 	}
 	// TODO support manual download and installation of kubernetes-mcp-server as a last resort
 	return nil, errors.New("no command found to start the Kubernetes MCP server")


### PR DESCRIPTION
It may be useful for higher-level tools to know how to start MCP servers for detected features( for example to add configuration to Claude desktop, VS Code, Cursor, etc).

This PR adds to the `discover` output the commands necessary for starting an MCP server for supported features.

```
   "tools" : [
      {
         "name" : "fs",
         "reason" : "filesystem is accessible"
      },
      {
         "mcp_commands" : [
            {
               "args" : [
                  "-y",
                  "kubernetes-mcp-server@latest"
               ],
               "cmd" : "npx"
            },
            {
               "args" : [
                  "kubernetes-mcp-server@latest"
               ],
               "cmd" : "uvx"
            }
         ],
         "name" : "kubernetes",
         "reason" : "default kubeconfig file found"
      }
   ],
```