### PR TITLE
feat: policies for tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cloudwego/eino-ext/components/model/ollama v0.1.0
 	github.com/cloudwego/eino-ext/components/tool/mcp v0.0.3
 	github.com/getkin/kin-openapi v0.118.0
+	github.com/invopop/yaml v0.1.0
 	github.com/mark3labs/mcp-go v0.36.0
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/afero v1.14.0
@@ -61,7 +62,6 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect

--- a/pkg/api/features.go
+++ b/pkg/api/features.go
@@ -9,7 +9,8 @@ type BasicFeatureProvider struct {
 type Feature[a FeatureAttributes, b any] interface {
 	Attributes() a
 	Data() b
-	IsAvailable(cfg *config.Config) bool
+	IsAvailable(cfg *config.Config, policies any) bool
+	GetDefaultPolicies() map[string]any
 }
 
 type FeatureAttributes interface {

--- a/pkg/features/discover.go
+++ b/pkg/features/discover.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/manusa/ai-cli/pkg/config"
 	"github.com/manusa/ai-cli/pkg/inference"
+	"github.com/manusa/ai-cli/pkg/policies"
 	"github.com/manusa/ai-cli/pkg/tools"
 )
 
@@ -62,8 +63,8 @@ func toHumanReadableToolsProvider(provider tools.Provider) string {
 	return ret.String()
 }
 
-func Discover(cfg *config.Config) *Features {
-	availableInferences, notAvailableInferences := inference.Discover(cfg)
+func Discover(cfg *config.Config, policies *policies.Policies) *Features {
+	availableInferences, notAvailableInferences := inference.Discover(cfg, nil) // TODO: pass preferences for inference
 
 	var selectedInference *inference.Provider
 	if cfg.Inference != nil {
@@ -78,12 +79,22 @@ func Discover(cfg *config.Config) *Features {
 		// For now, we just select the first available inference
 		selectedInference = &availableInferences[0]
 	}
-	availableTools, notAvailableTools := tools.Discover(cfg)
+	toolsPolicies := map[string]any{}
+	if policies != nil {
+		toolsPolicies = policies.Tools
+	}
+	availableTools, notAvailableTools := tools.Discover(cfg, toolsPolicies)
 	return &Features{
 		Inferences:             availableInferences,
 		InferencesNotAvailable: notAvailableInferences,
 		Inference:              selectedInference,
 		Tools:                  availableTools,
 		ToolsNotAvailable:      notAvailableTools,
+	}
+}
+
+func GetDefaultPolicies() map[string]any {
+	return map[string]any{
+		"tools": tools.GetDefaultPolicies(),
 	}
 }

--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -76,8 +76,12 @@ func (t *InferenceProvider) GetModels(_ context.Context, _ *config.Config) ([]st
 	return []string{}, nil
 }
 
-func (t *InferenceProvider) IsAvailable(_ *config.Config) bool {
+func (t *InferenceProvider) IsAvailable(_ *config.Config, _ any) bool {
 	return t.Available
+}
+
+func (t *InferenceProvider) GetDefaultPolicies() map[string]any {
+	return nil
 }
 
 func (t *InferenceProvider) GetInference(_ context.Context, _ *config.Config) (model.ToolCallingChatModel, error) {
@@ -91,7 +95,7 @@ func TestDiscoverInference(t *testing.T) {
 	testCase(t, func(c *testContext) {
 		inference.Register(&InferenceProvider{Name: "availableProvider", Available: true})
 		inference.Register(&InferenceProvider{Name: "unavailableProvider", Available: false})
-		features := Discover(config.New())
+		features := Discover(config.New(), nil)
 		t.Run("With one available provider returns features", func(t *testing.T) {
 			assert.NotNil(t, features, "expected an inference to be returned")
 		})
@@ -116,7 +120,7 @@ func TestDiscoverKnownExplicitInference(t *testing.T) {
 		cfg.Inference = func(s string) *string {
 			return &s
 		}("availableProvider")
-		features := Discover(cfg)
+		features := Discover(cfg, nil)
 		t.Run("With one available provider returns features", func(t *testing.T) {
 			assert.NotNil(t, features, "expected an inference to be returned")
 		})
@@ -141,7 +145,7 @@ func TestDiscoverUnknownExplicitInference(t *testing.T) {
 		cfg.Inference = func(s string) *string {
 			return &s
 		}("otherProvider")
-		features := Discover(cfg)
+		features := Discover(cfg, nil)
 		t.Run("With one available provider returns features", func(t *testing.T) {
 			assert.NotNil(t, features, "expected an inference to be returned")
 		})
@@ -164,7 +168,7 @@ func TestDiscoverMarshal(t *testing.T) {
 		inference.Register(&gemini.Provider{})
 		inference.Register(&ollama.Provider{})
 		tools.Register(&fs.Provider{})
-		features := Discover(config.New())
+		features := Discover(config.New(), nil)
 		bytes, err := json.Marshal(features)
 		t.Run("Marshalling returns no error", func(t *testing.T) {
 			assert.Nil(t, err, "expected no error when marshalling inferences")

--- a/pkg/inference/discover.go
+++ b/pkg/inference/discover.go
@@ -61,10 +61,10 @@ func Clear() {
 }
 
 // Discover the available and not available inference providers based on the user preferences
-func Discover(cfg *config.Config) (availableInferences []Provider, notAvailableInferences []Provider) {
+func Discover(cfg *config.Config, policies map[string]any) (availableInferences []Provider, notAvailableInferences []Provider) {
 	availableInferences, notAvailableInferences = []Provider{}, []Provider{}
 	for _, provider := range providers {
-		if provider.IsAvailable(cfg) {
+		if provider.IsAvailable(cfg, policies) {
 			availableInferences = append(availableInferences, provider)
 		} else {
 			notAvailableInferences = append(notAvailableInferences, provider)

--- a/pkg/inference/discover_test.go
+++ b/pkg/inference/discover_test.go
@@ -38,8 +38,12 @@ func (t *TestProvider) Data() Data {
 	}
 }
 
-func (t *TestProvider) IsAvailable(_ *config.Config) bool {
+func (t *TestProvider) IsAvailable(_ *config.Config, _ any) bool {
 	return t.Available
+}
+
+func (t *TestProvider) GetDefaultPolicies() map[string]any {
+	return nil
 }
 
 func (t *TestProvider) GetModels(_ context.Context, _ *config.Config) ([]string, error) {
@@ -99,7 +103,7 @@ func TestDiscover(t *testing.T) {
 	// With no providers registered, it should returns empty
 	testCase(t, func(c *testContext) {
 		t.Run("With no providers registered returns empty", func(t *testing.T) {
-			availableInferences, notAvailableInferences := Discover(config.New())
+			availableInferences, notAvailableInferences := Discover(config.New(), nil)
 			assert.Empty(t, availableInferences, "expected no inferences to be returned when no providers are registered")
 			assert.Empty(t, notAvailableInferences, "expected no not available inferences to be returned when no providers are registered")
 		})
@@ -108,7 +112,7 @@ func TestDiscover(t *testing.T) {
 	testCase(t, func(c *testContext) {
 		Register(&TestProvider{Name: "availableProvider", Local: true, Public: false, Available: true})
 		Register(&TestProvider{Name: "unavailableProvider", Local: true, Public: false, Available: false})
-		availableInferences, notAvailableInferences := Discover(config.New())
+		availableInferences, notAvailableInferences := Discover(config.New(), nil)
 		t.Run("With one available provider returns that provider", func(t *testing.T) {
 			assert.Len(t, availableInferences, 1, "expected one available provider to be registered")
 			assert.Equal(t, "availableProvider", availableInferences[0].Attributes().Name(),

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -38,7 +38,7 @@ func (geminiProvider *Provider) Data() inference.Data {
 	}
 }
 
-func (geminiProvider *Provider) IsAvailable(cfg *config.Config) bool {
+func (geminiProvider *Provider) IsAvailable(cfg *config.Config, policies any) bool {
 	available := cfg.GoogleApiKey != ""
 	if available {
 		geminiProvider.Reason = "GEMINI_API_KEY is set"
@@ -64,6 +64,10 @@ func (geminiProvider *Provider) MarshalJSON() ([]byte, error) {
 		Attributes: geminiProvider.Attributes(),
 		Data:       geminiProvider.Data(),
 	})
+}
+
+func (geminiProvider *Provider) GetDefaultPolicies() map[string]any {
+	return nil
 }
 
 var instance = &Provider{}

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -72,7 +72,7 @@ func (ollamaProvider *Provider) GetModels(_ context.Context, _ *config.Config) (
 	return modelsNames, nil
 }
 
-func (ollamaProvider *Provider) IsAvailable(cfg *config.Config) bool {
+func (ollamaProvider *Provider) IsAvailable(cfg *config.Config, policies any) bool {
 	baseURL := ollamaProvider.baseURL()
 	isBaseURLConfigured := ollamaProvider.isBaseURLConfigured()
 	resp, err := http.Get(baseURL + "/v1/models")
@@ -133,6 +133,10 @@ func (ollamaProvider *Provider) baseURL() string {
 
 func (ollamaProvider *Provider) isBaseURLConfigured() bool {
 	return os.Getenv(ollamaHostEnvVar) != ""
+}
+
+func (ollamaProvider *Provider) GetDefaultPolicies() map[string]any {
+	return nil
 }
 
 var instance = &Provider{}

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -1,0 +1,54 @@
+package policies
+
+import (
+	"encoding/json"
+)
+
+type Policies struct {
+	Tools map[string]any `yaml:"tools"`
+}
+
+type ToolPolicies struct {
+	Enabled  bool `yaml:"enabled" json:"enabled"`
+	ReadOnly bool `yaml:"read-only" json:"read-only"`
+}
+
+// IsEnabledByPolicies checks if the tool is enabled by policies
+// If the tool policies are nil, it returns true
+// If the tool policies are not nil, it returns the value of the Enabled field
+// If the tool policies are not a valid ToolPolicies struct, it returns false
+func IsEnabledByPolicies(toolPolicies any) bool {
+	if toolPolicies == nil {
+		return true
+	}
+	jsonBody, err := json.Marshal(toolPolicies)
+	if err != nil {
+		return false
+	}
+	var structuredPolicies ToolPolicies
+	err = json.Unmarshal(jsonBody, &structuredPolicies)
+	if err != nil {
+		return false
+	}
+	return structuredPolicies.Enabled
+}
+
+// IsReadOnlyByPolicies checks if the tool must be read-only by policies
+// If the tool policies are nil, it returns false
+// If the tool policies are not nil, it returns the value of the ReadOnly field
+// If the tool policies are not a valid ToolPolicies struct, it returns true
+func IsReadOnlyByPolicies(toolPolicies any) bool {
+	if toolPolicies == nil {
+		return false
+	}
+	jsonBody, err := json.Marshal(toolPolicies)
+	if err != nil {
+		return true
+	}
+	var structuredPolicies ToolPolicies
+	err = json.Unmarshal(jsonBody, &structuredPolicies)
+	if err != nil {
+		return true
+	}
+	return structuredPolicies.ReadOnly
+}

--- a/pkg/policies/read.go
+++ b/pkg/policies/read.go
@@ -1,0 +1,20 @@
+package policies
+
+import (
+	"os"
+
+	"github.com/invopop/yaml"
+)
+
+func Read(policiesFile string) (*Policies, error) {
+	policies := Policies{}
+	fileContent, err := os.ReadFile(policiesFile)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(fileContent, &policies)
+	if err != nil {
+		return nil, err
+	}
+	return &policies, nil
+}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -50,9 +50,9 @@ func Clear() {
 }
 
 // Discover the available tools based on the user preferences
-func Discover(cfg *config.Config) (availableTools []Provider, notAvailableTools []Provider) {
+func Discover(cfg *config.Config, policies map[string]any) (availableTools []Provider, notAvailableTools []Provider) {
 	for _, provider := range providers {
-		if provider.IsAvailable(cfg) {
+		if provider.IsAvailable(cfg, policies[provider.Attributes().Name()]) {
 			availableTools = append(availableTools, provider)
 		} else {
 			notAvailableTools = append(notAvailableTools, provider)
@@ -65,4 +65,13 @@ func Discover(cfg *config.Config) (availableTools []Provider, notAvailableTools 
 		return strings.Compare(a.Attributes().Name(), b.Attributes().Name())
 	})
 	return availableTools, notAvailableTools
+}
+
+func GetDefaultPolicies() map[string]any {
+	policies := make(map[string]any)
+	for _, provider := range providers {
+		providerPolicies := provider.GetDefaultPolicies()
+		policies[provider.Attributes().Name()] = providerPolicies
+	}
+	return policies
 }

--- a/pkg/tools/discover_test.go
+++ b/pkg/tools/discover_test.go
@@ -34,8 +34,12 @@ func (t *TestProvider) Data() Data {
 	}
 }
 
-func (t *TestProvider) IsAvailable(_ *config.Config) bool {
+func (t *TestProvider) IsAvailable(_ *config.Config, _ any) bool {
 	return t.Available
+}
+
+func (t *TestProvider) GetDefaultPolicies() map[string]any {
+	return nil
 }
 
 func (t *TestProvider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
@@ -91,7 +95,7 @@ func TestDiscover(t *testing.T) {
 	// With no providers registered, it should returns empty
 	testCase(t, func(c *testContext) {
 		t.Run("With no providers registered returns empty", func(t *testing.T) {
-			availableTools, notAvailableTools := Discover(config.New())
+			availableTools, notAvailableTools := Discover(config.New(), nil)
 			assert.Empty(t, availableTools, "expected no available tools to be returned when no providers are registered")
 			assert.Empty(t, notAvailableTools, "expected no not available tools to be returned when no providers are registered")
 		})
@@ -100,7 +104,7 @@ func TestDiscover(t *testing.T) {
 	testCase(t, func(c *testContext) {
 		Register(&TestProvider{Name: "availableProvider", Available: true})
 		Register(&TestProvider{Name: "unavailableProvider", Available: false})
-		availableTools, notAvailableTools := Discover(config.New())
+		availableTools, notAvailableTools := Discover(config.New(), nil)
 		t.Run("With one available provider returns that provider", func(t *testing.T) {
 			assert.Len(t, availableTools, 1, "expected one available provider to be registered")
 			assert.Equal(t, "availableProvider", availableTools[0].Attributes().Name(),
@@ -114,7 +118,7 @@ func TestDiscoverMarshalling(t *testing.T) {
 	testCase(t, func(c *testContext) {
 		Register(&TestProvider{Name: "provider-one", Available: true})
 		Register(&TestProvider{Name: "provider-two", Available: true})
-		availableTools, notAvailableTools := Discover(config.New())
+		availableTools, notAvailableTools := Discover(config.New(), nil)
 		bytes, err := json.Marshal(availableTools)
 		t.Run("Marshalling returns no error", func(t *testing.T) {
 			assert.Nil(t, err, "expected no error when marshalling inferences")


### PR DESCRIPTION
This PR introduces the concept of policies (#31), only for tools for the moment.

By default, `ai-cli` does not consider any policies.

The user can get the format of the policies configuration file:

```
 % ./ai-cli discover --show-policies-sample
tools:
    fs:
        enabled: false
        read-only: false
    kubernetes:
        disable-destructive: false
        enabled: false
        read-only: false
```

then adapt the file to its needs, for example:

```
tools:
    fs:
        enabled: false
        read-only: false
    kubernetes:
        disable-destructive: false
        enabled: true
        read-only: true
```

then run the discover command with these policies:

```
{
   "inference" : null,
   "inferences" : [],
   "inferencesNotAvailable" : [
      {
         "local" : false,
         "models" : null,
         "name" : "gemini",
         "public" : true,
         "reason" : "GEMINI_API_KEY is not set"
      },
      {
         "local" : true,
         "models" : null,
         "name" : "ollama",
         "public" : false,
         "reason" : "http://localhost:11434 is not accessible"
      }
   ],
   "tools" : [
      {
         "mcp_settings" : {
            "args" : [
               "kubernetes-mcp-server@latest",
               "--read-only"
            ],
            "command" : "uvx",
            "type" : "stdio"
         },
         "name" : "kubernetes",
         "reason" : "default kubeconfig file found"
      }
   ],
   "toolsNotAvailable" : [
      {
         "name" : "fs",
         "reason" : "filesystem is not authorized by policies"
      }
   ]
}
```

As a result in this example:
- fs tool is not enabled, because not authorized by policies
- the `--read-only` flag is added to the command to be used to start the Kubernetes MCP server, to enforce the read-only policy for Kubernetes