### PR TITLE
feat: add postgresql tool discovery

### DIFF
--- a/pkg/cmd/discover_test.go
+++ b/pkg/cmd/discover_test.go
@@ -58,7 +58,9 @@ func (s *DiscoverTestSuite) TestOutputText() {
 			"  - github\n" +
 			"    Reason: GITHUB_PERSONAL_ACCESS_TOKEN is not set\n" +
 			"  - kubernetes\n" +
-			"    Reason: no kubeconfig file found in the default location\n"
+			"    Reason: no kubeconfig file found in the default location\n" +
+			"  - postgresql\n" +
+			"    Reason: DATABASE_URI and PGPASSWORD are not set\n"
 		s.Equal(expectedOutput, output, "Expected output does not match")
 	})
 }
@@ -82,7 +84,8 @@ func (s *DiscoverTestSuite) TestOutputJson() {
 			`"tools":[{"name":"fs","reason":"filesystem is accessible"}],` +
 			`"toolsNotAvailable":[` +
 			`{"name":"github","reason":"GITHUB_PERSONAL_ACCESS_TOKEN is not set"},` +
-			`{"name":"kubernetes","reason":"no kubeconfig file found in the default location"}` +
+			`{"name":"kubernetes","reason":"no kubeconfig file found in the default location"},` +
+			`{"name":"postgresql","reason":"DATABASE_URI and PGPASSWORD are not set"}` +
 			`]}`
 		s.JSONEq(expectedOutput, output, "Expected JSON output does not match")
 	})

--- a/pkg/cmd/modules.go
+++ b/pkg/cmd/modules.go
@@ -5,7 +5,9 @@ import (
 	_ "github.com/manusa/ai-cli/pkg/inference/lmstudio"
 	_ "github.com/manusa/ai-cli/pkg/inference/ollama"
 	_ "github.com/manusa/ai-cli/pkg/inference/ramalama"
+
 	_ "github.com/manusa/ai-cli/pkg/tools/fs"
 	_ "github.com/manusa/ai-cli/pkg/tools/github"
 	_ "github.com/manusa/ai-cli/pkg/tools/kubernetes"
+	_ "github.com/manusa/ai-cli/pkg/tools/postgresql"
 )

--- a/pkg/tools/postgresql/postgresql.go
+++ b/pkg/tools/postgresql/postgresql.go
@@ -1,0 +1,198 @@
+package postgresql
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/manusa/ai-cli/pkg/policies"
+	"github.com/manusa/ai-cli/pkg/tools"
+	"github.com/manusa/ai-cli/pkg/tools/utils/eino"
+)
+
+type Provider struct {
+	tools.BasicToolsProvider
+	ReadOnly bool
+}
+
+type PostgresqlPolicies struct {
+	policies.ToolPolicies
+}
+
+var _ tools.Provider = &Provider{}
+
+const (
+	databaseUriEnvVar = "DATABASE_URI"
+
+	pgDatabaseEnvVar  = "PGDATABASE"
+	defaultPgDatabase = "postgres"
+
+	pgHostEnvVar  = "PGHOST"
+	defaultPgHost = "localhost"
+
+	pgPortEnvVar  = "PGPORT"
+	defaultPgPort = "5432"
+
+	pgUserEnvVar  = "PGUSER"
+	defaultPgUser = "postgres"
+
+	pgPasswordEnvVar = "PGPASSWORD"
+)
+
+var (
+	supportedMcpSettings = map[string]api.McpSettings{
+		"podman": {
+			Type:    api.McpTypeStdio,
+			Command: "podman", // TODO: Note that this is platform dependent (on windows this is podman.exe)
+			Args: []string{
+				"run",
+				"-i",
+				"--rm",
+				"-e",
+				"DATABASE_URI",
+				"crystaldba/postgres-mcp",
+			},
+		},
+	}
+)
+
+func (p *Provider) Attributes() tools.Attributes {
+	return tools.Attributes{
+		BasicFeatureAttributes: api.BasicFeatureAttributes{
+			FeatureName: "postgresql",
+		},
+	}
+}
+
+func (p *Provider) Data() tools.Data {
+	data := tools.Data{
+		BasicFeatureData: api.BasicFeatureData{
+			Reason: p.Reason,
+		},
+	}
+	settings, err := p.findBestMcpServerSettings(p.ReadOnly)
+	if err == nil {
+		data.McpSettings = settings
+	}
+	return data
+}
+
+func (p *Provider) IsAvailable(_ *config.Config, toolPolicies any) bool {
+	if !policies.IsEnabledByPolicies(toolPolicies) {
+		p.Reason = "postgresql is not authorized by policies"
+		return false
+	}
+
+	if policies.IsReadOnlyByPolicies(toolPolicies) {
+		p.ReadOnly = true
+	}
+
+	if available := os.Getenv(databaseUriEnvVar) != ""; available {
+		p.Reason = fmt.Sprintf("%s is set", databaseUriEnvVar)
+		return true
+	}
+
+	if pgpassword := os.Getenv(pgPasswordEnvVar); pgpassword != "" {
+		p.Reason = fmt.Sprintf("%s is set (will also consider %s)", pgPasswordEnvVar, strings.Join([]string{pgDatabaseEnvVar, pgHostEnvVar, pgPortEnvVar, pgUserEnvVar}, ", "))
+		return true
+	}
+
+	p.Reason = fmt.Sprintf("%s and %s are not set", databaseUriEnvVar, pgPasswordEnvVar)
+
+	return false
+}
+
+func (p *Provider) GetTools(ctx context.Context, _ *config.Config) ([]*api.Tool, error) {
+	mcpSettings, err := p.findBestMcpServerSettings(p.ReadOnly)
+	if err != nil || mcpSettings.Type != api.McpTypeStdio {
+		return nil, err
+	}
+
+	cli, err := eino.StartMcp(ctx, slices.Concat([]string{mcpSettings.Command}, mcpSettings.Args))
+	if err != nil {
+		return nil, err
+	}
+	return eino.GetTools(ctx, cli)
+}
+
+func (p *Provider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(tools.Report{
+		Attributes: p.Attributes(),
+		Data:       p.Data(),
+	})
+}
+
+func (p *Provider) findBestMcpServerSettings(readOnly bool) (*api.McpSettings, error) {
+	for command, settings := range supportedMcpSettings {
+		if commandExists(command) {
+			if readOnly {
+				settings.Args = append(settings.Args, "--access-mode=restricted")
+			} else {
+				settings.Args = append(settings.Args, "--access-mode=unrestricted")
+			}
+
+			// Get or build URI
+			uri := ""
+			if databaseUri := os.Getenv(databaseUriEnvVar); databaseUri != "" {
+				uri = databaseUri
+			} else if os.Getenv(pgPasswordEnvVar) != "" {
+				uri = fmt.Sprintf(
+					"postgresql://%s:%s@%s:%s/%s",
+					p.getEnvVarValueOrDefault(pgUserEnvVar, defaultPgUser),
+					os.Getenv(pgPasswordEnvVar),
+					p.getEnvVarValueOrDefault(pgHostEnvVar, defaultPgHost),
+					p.getEnvVarValueOrDefault(pgPortEnvVar, defaultPgPort),
+					p.getEnvVarValueOrDefault(pgDatabaseEnvVar, defaultPgDatabase),
+				)
+			}
+
+			// replace localhost with host.containers.internal in the DATABASE_URI environment variable
+			for i, arg := range settings.Args {
+				if arg == "DATABASE_URI" {
+					settings.Args[i] = fmt.Sprintf("DATABASE_URI=%s", strings.Replace(uri, "localhost", "host.containers.internal", 1))
+				}
+			}
+			return &settings, nil
+		}
+	}
+	return nil, errors.New("no suitable MCP settings found for the PostgreSQL MCP server")
+}
+
+func commandExists(command string) bool {
+	_, err := exec.LookPath(command)
+	return err == nil
+}
+
+func (p *Provider) GetDefaultPolicies() map[string]any {
+	var policies = PostgresqlPolicies{}
+	jsonBody, err := json.Marshal(policies)
+	if err != nil {
+		return nil
+	}
+	var policiesMap map[string]any
+	err = json.Unmarshal(jsonBody, &policiesMap)
+	if err != nil {
+		return nil
+	}
+	return policiesMap
+}
+
+func (p *Provider) getEnvVarValueOrDefault(envVar string, defaultValue string) string {
+	if value := os.Getenv(envVar); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+var instance = &Provider{}
+
+func init() {
+	tools.Register(instance)
+}

--- a/pkg/tools/postgresql/postgresql_test.go
+++ b/pkg/tools/postgresql/postgresql_test.go
@@ -1,0 +1,33 @@
+package postgresql
+
+import (
+	"testing"
+)
+
+func TestIsAvailable(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		databaseUri string
+		pgPassword  string
+		// expected values
+		available bool
+		reason    string
+	}{
+		{name: "available via URI", databaseUri: "postgresql://localhost:5432/test", pgPassword: "", available: true, reason: "DATABASE_URI is set"},
+		{name: "available via password", databaseUri: "", pgPassword: "SeCrEt", available: true, reason: "PGPASSWORD is set (will also consider PGDATABASE, PGHOST, PGPORT, PGUSER)"},
+		{name: "not available", databaseUri: "", pgPassword: "", available: false, reason: "DATABASE_URI and PGPASSWORD are not set"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DATABASE_URI", tt.databaseUri)
+			t.Setenv("PGPASSWORD", tt.pgPassword)
+			provider := &Provider{}
+			available := provider.IsAvailable(nil, nil)
+			if available != tt.available {
+				t.Errorf("expected postgresql to be %v", tt.available)
+			}
+			if provider.Reason != tt.reason {
+				t.Errorf("expected reason to be %s, but got %s", tt.reason, provider.Reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #38 

The Postgresql MCP Server (https://github.com/crystaldba/postgres-mcp) is started when a connection is found, and a `read-only` policy is supported 