### PR TITLE
fix: use fqn for postgres image name

### DIFF
--- a/pkg/tools/postgresql/postgresql.go
+++ b/pkg/tools/postgresql/postgresql.go
@@ -57,7 +57,7 @@ var (
 				"--rm",
 				"-e",
 				"DATABASE_URI",
-				"crystaldba/postgres-mcp",
+				"docker.io/crystaldba/postgres-mcp",
 			},
 		},
 	}


### PR DESCRIPTION
With fully qualified name, podman will ask which registry the user wants to pull the image from