### PR TITLE
fix: make test build on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean: ## Clean up all build artifacts
 
 .PHONY: build
 build: clean tidy format lint ## Build the project
-	go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME) ./cmd
+	go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME)$(if $(findstring windows,$(shell go env GOOS)),.exe,) ./cmd
 
 .PHONY: build-all-platforms
 build-all-platforms: clean tidy format lint ## Build the project for all platforms

--- a/pkg/cmd/discover_test.go
+++ b/pkg/cmd/discover_test.go
@@ -18,9 +18,12 @@ type DiscoverTestSuite struct {
 }
 
 func (s *DiscoverTestSuite) SetupTest() {
+	// Get the tmpdir before cleaning the environment
+	// to avoid error on Windows
+	tmpdir := s.T().TempDir()
 	s.originalEnv = os.Environ()
 	os.Clearenv()
-	config.FileSystem = afero.NewBasePathFs(afero.NewOsFs(), s.T().TempDir())
+	config.FileSystem = afero.NewBasePathFs(afero.NewOsFs(), tmpdir)
 	s.rootCmd = NewAiCli()
 }
 


### PR DESCRIPTION
Changes to make `make test build` work on Windows

(`make build` needs a cygwin environment)
