### PR TITLE
feat: indent JSON output

### DIFF
--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -89,7 +89,7 @@ func (o *DiscoverCmdOptions) Run(_ *cobra.Command) error {
 	// TODO: maybe create an output package to handle different output formats globally
 	switch o.outputFormat {
 	case "json":
-		bytes, err := json.Marshal(discoveredFeatures)
+		bytes, err := json.MarshalIndent(discoveredFeatures, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal discovered features to JSON: %w", err)
 		}


### PR DESCRIPTION
Indent the JSON output, for better readability during dev/debug (particularly on Windows there are no tools like json_tt or json_reformat installed by default)