### PR TITLE
fix: remove TODO as commands without exe works on Windows

### DIFF
--- a/pkg/tools/github/github.go
+++ b/pkg/tools/github/github.go
@@ -35,7 +35,7 @@ var (
 	supportedMcpSettings = map[string]api.McpSettings{
 		"podman": {
 			Type:    api.McpTypeStdio,
-			Command: "podman", // TODO: Note that this is platform dependent (on windows this is podman.exe)
+			Command: "podman",
 			Args: []string{
 				"run",
 				"-i",

--- a/pkg/tools/kubernetes/kubernetes.go
+++ b/pkg/tools/kubernetes/kubernetes.go
@@ -42,13 +42,13 @@ var (
 	supportedMcpSettings = map[string]api.McpSettings{
 		"uvx": {
 			Type:    api.McpTypeStdio,
-			Command: "uvx", // TODO: Note that this is platform dependent (on windows this is uvx.exe)
+			Command: "uvx",
 			Args:    []string{"kubernetes-mcp-server@latest"},
 		},
 		"npx": {
 			Type:    api.McpTypeStdio,
 			Command: "npx",
-			Args:    []string{"-y", "kubernetes-mcp-server@latest"}, // TODO: Note that this is platform dependent (on windows this is uvx.exe)
+			Args:    []string{"-y", "kubernetes-mcp-server@latest"},
 		},
 	}
 )

--- a/pkg/tools/postgresql/postgresql.go
+++ b/pkg/tools/postgresql/postgresql.go
@@ -50,7 +50,7 @@ var (
 	supportedMcpSettings = map[string]api.McpSettings{
 		"podman": {
 			Type:    api.McpTypeStdio,
-			Command: "podman", // TODO: Note that this is platform dependent (on windows this is podman.exe)
+			Command: "podman",
 			Args: []string{
 				"run",
 				"-i",


### PR DESCRIPTION
Tested on Windows, the command name without `exe` is handled correctly. I don't think it is necessary to explicitly add the suffix