### PR TITLE
refactor(discovery): move discovery generic JSON output to package method

### DIFF
--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/invopop/yaml"
@@ -86,14 +85,13 @@ func (o *DiscoverCmdOptions) Run(_ *cobra.Command) error {
 	}
 
 	discoveredFeatures := features.Discover(config.New(), userPolicies)
-	// TODO: maybe create an output package to handle different output formats globally
 	switch o.outputFormat {
 	case "json":
-		bytes, err := json.MarshalIndent(discoveredFeatures, "", "  ")
+		jsonString, err := discoveredFeatures.ToJSON()
 		if err != nil {
 			return fmt.Errorf("failed to marshal discovered features to JSON: %w", err)
 		}
-		_, _ = fmt.Printf("%s\n", bytes)
+		_, _ = fmt.Printf("%s\n", jsonString)
 	case "text":
 		_, _ = fmt.Print(discoveredFeatures.ToHumanReadable())
 	}

--- a/pkg/features/discover.go
+++ b/pkg/features/discover.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -17,6 +18,12 @@ type Features struct {
 	Inference              *api.InferenceProvider  `json:"inference"`              // The selected inference provider based on user preferences or auto-detection, or nil if no inference provider is selected
 	Tools                  []api.ToolsProvider     `json:"tools"`                  // List of available tools
 	ToolsNotAvailable      []api.ToolsProvider     `json:"toolsNotAvailable"`      // List of not available tools
+}
+
+// ToJSON converts the features to a generic JSON string representation.
+func (f *Features) ToJSON() (string, error) {
+	bytes, err := json.MarshalIndent(f, "", "  ")
+	return string(bytes), err
 }
 
 // ToHumanReadable converts the features to a human-readable string representation.

--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -2,7 +2,6 @@ package features
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -16,40 +15,8 @@ import (
 	"github.com/manusa/ai-cli/pkg/tools"
 	"github.com/manusa/ai-cli/pkg/tools/fs"
 	"github.com/manusa/ai-cli/pkg/tools/kubernetes"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
-
-type testContext struct {
-	originalEnv []string
-}
-
-func (c *testContext) beforeEach(t *testing.T) {
-	t.Helper()
-	c.originalEnv = os.Environ()
-	os.Clearenv()
-	inference.Clear()
-	tools.Clear()
-}
-
-func (c *testContext) afterEach(t *testing.T) {
-	t.Helper()
-	os.Clearenv()
-	for _, env := range c.originalEnv {
-		if key, value, found := strings.Cut(env, "="); found {
-			_ = os.Setenv(key, value)
-		}
-	}
-}
-
-func testCase(t *testing.T, test func(c *testContext)) {
-	testCaseWithContext(t, &testContext{}, test)
-}
-
-func testCaseWithContext(t *testing.T, ctx *testContext, test func(c *testContext)) {
-	ctx.beforeEach(t)
-	t.Cleanup(func() { ctx.afterEach(t) })
-	test(ctx)
-}
 
 type TestProvider struct {
 	Available bool `json:"-"`
@@ -81,266 +48,275 @@ func (t *TestToolsProvider) GetTools(_ context.Context, _ *config.Config) ([]*ap
 	return nil, nil
 }
 
-func TestDiscoverInference(t *testing.T) {
+type DiscoverTestSuite struct {
+	suite.Suite
+	originalEnv []string
+}
+
+func (s *DiscoverTestSuite) SetupTest() {
+	s.originalEnv = os.Environ()
+	os.Clearenv()
+	inference.Clear()
+	tools.Clear()
+}
+
+func (s *DiscoverTestSuite) TearDownTest() {
+	os.Clearenv()
+	for _, env := range s.originalEnv {
+		if key, value, found := strings.Cut(env, "="); found {
+			_ = os.Setenv(key, value)
+		}
+	}
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInference() {
 	// With one available inference provider, it should return that provider
-	testCase(t, func(c *testContext) {
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-unavailable", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+		},
+		TestProvider{Available: true},
+	})
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-unavailable", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: false},
-		})
-		features := Discover(config.New(), nil)
-		t.Run("With one available provider returns features", func(t *testing.T) {
-			assert.NotNil(t, features, "expected an inference to be returned")
-		})
-		t.Run("With one available provider Inferences has one provider", func(t *testing.T) {
-			assert.Len(t, features.Inferences, 1, "expected one inference provider to be returned")
-			assert.Equal(t, "provider-available", features.Inferences[0].Attributes().Name(),
-				"expected the available provider to be returned")
-		})
-		t.Run("With one available provider Inference is set to that provider", func(t *testing.T) {
-			assert.Equal(t, "provider-available", (*features.Inference).Attributes().Name(),
-				"expected the available provider to be returned")
-		})
+		},
+		TestProvider{Available: false},
+	})
+	features := Discover(config.New(), nil)
+	s.Run("With one available provider returns features", func() {
+		s.NotNil(features, "expected an inference to be returned")
+	})
+	s.Run("With one available provider Inferences has one provider", func() {
+		s.Len(features.Inferences, 1, "expected one inference provider to be returned")
+		s.Equal("provider-available", features.Inferences[0].Attributes().Name(),
+			"expected the available provider to be returned")
+	})
+	s.Run("With one available provider Inference is set to that provider", func() {
+		s.Equal("provider-available", (*features.Inference).Attributes().Name(),
+			"expected the available provider to be returned")
 	})
 }
 
-func TestDiscoverInferenceConfiguredProvider(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-1", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProvider() {
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-1", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-2", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+		},
+		TestProvider{Available: true},
+	})
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-2", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-3", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+		},
+		TestProvider{Available: true},
+	})
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-3", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		cfg := config.New()
-		cfg.Inference = func(s string) *string {
-			return &s
-		}("provider-2")
-		features := Discover(cfg, nil)
-		t.Run("Inference is set to configured provider", func(t *testing.T) {
-			assert.Equal(t, "provider-2", (*features.Inference).Attributes().Name(),
-				"expected the configured provider to be returned")
-		})
+		},
+		TestProvider{Available: true},
+	})
+	cfg := config.New()
+	cfg.Inference = func(s string) *string {
+		return &s
+	}("provider-2")
+	features := Discover(cfg, nil)
+	s.Run("Inference is set to configured provider", func() {
+		s.Equal("provider-2", (*features.Inference).Attributes().Name(),
+			"expected the configured provider to be returned")
 	})
 }
 
-func TestDiscoverInferenceConfiguredProviderUnknown(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-1", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProviderUnknown() {
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-1", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-2", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
+		},
+		TestProvider{Available: true},
+	})
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-2", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		cfg := config.New()
-		cfg.Inference = func(s string) *string {
-			return &s
-		}("unknown-provider")
-		features := Discover(cfg, nil)
-		t.Run("Inference IS NOT set", func(t *testing.T) {
-			assert.Nil(t, features.Inference, "expected nil inference to be returned")
-		})
+		},
+		TestProvider{Available: true},
+	})
+	cfg := config.New()
+	cfg.Inference = func(s string) *string {
+		return &s
+	}("unknown-provider")
+	features := Discover(cfg, nil)
+	s.Run("Inference IS NOT set", func() {
+		s.Nil(features.Inference, "expected nil inference to be returned")
 	})
 }
 
-func TestDiscoverTools(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		tools.Register(&TestToolsProvider{
-			tools.BasicToolsProvider{
-				BasicToolsAttributes: tools.BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
-				},
+func (s *DiscoverTestSuite) TestDiscoverTools() {
+	tools.Register(&TestToolsProvider{
+		tools.BasicToolsProvider{
+			BasicToolsAttributes: tools.BasicToolsAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
 			},
-			TestProvider{Available: true},
-		})
-		features := Discover(config.New(), nil)
-		t.Run("With one available provider returns features", func(t *testing.T) {
-			assert.NotNil(t, features, "expected features to be returned")
-		})
-		t.Run("With one available Tools provider has one provider", func(t *testing.T) {
-			assert.Len(t, features.ToolsNotAvailable, 0, "expected no not available tools provider to be returned")
-			assert.Len(t, features.Tools, 1, "expected one tool provider to be returned")
-			assert.Equal(t, "provider-available", features.Tools[0].Attributes().Name(),
-				"expected provider-available provider to be returned")
-		})
+		},
+		TestProvider{Available: true},
+	})
+	features := Discover(config.New(), nil)
+	s.Run("With one available provider returns features", func() {
+		s.NotNil(features, "expected features to be returned")
+	})
+	s.Run("With one available Tools provider has one provider", func() {
+		s.Len(features.ToolsNotAvailable, 0, "expected no not available tools provider to be returned")
+		s.Len(features.Tools, 1, "expected one tool provider to be returned")
+		s.Equal("provider-available", features.Tools[0].Attributes().Name(),
+			"expected provider-available provider to be returned")
 	})
 }
 
-func TestDiscoverToolsWithEnabledPolicies(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		tools.Register(&TestToolsProvider{
-			tools.BasicToolsProvider{
-				BasicToolsAttributes: tools.BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
-				},
+func (s *DiscoverTestSuite) TestDiscoverToolsWithEnabledPolicies() {
+	tools.Register(&TestToolsProvider{
+		tools.BasicToolsProvider{
+			BasicToolsAttributes: tools.BasicToolsAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
 			},
-			TestProvider{Available: true},
-		})
-		structuredPolicies := policies.Policies{
-			Tools: map[string]any{
-				"provider-available": map[string]any{
-					"enabled": true,
-				},
+		},
+		TestProvider{Available: true},
+	})
+	structuredPolicies := policies.Policies{
+		Tools: map[string]any{
+			"provider-available": map[string]any{
+				"enabled": true,
 			},
-		}
-		features := Discover(config.New(), &structuredPolicies)
-		t.Run("Tools is set to available AND enabled in policies providers", func(t *testing.T) {
-			assert.Len(t, features.ToolsNotAvailable, 0, "expected no not available tools provider to be returned")
-			assert.Len(t, features.Tools, 1, "expected one tool provider to be returned")
-			assert.Equal(t, "provider-available", features.Tools[0].Attributes().Name(),
-				"expected fs provider to be returned")
-		})
+		},
+	}
+	features := Discover(config.New(), &structuredPolicies)
+	s.Run("Tools is set to available AND enabled in policies providers", func() {
+		s.Len(features.ToolsNotAvailable, 0, "expected no not available tools provider to be returned")
+		s.Len(features.Tools, 1, "expected one tool provider to be returned")
+		s.Equal("provider-available", features.Tools[0].Attributes().Name(),
+			"expected fs provider to be returned")
 	})
 }
 
-func TestDiscoverToolsWithDisabledPolicies(t *testing.T) {
+func (s *DiscoverTestSuite) TestDiscoverToolsWithDisabledPolicies() {
 	// TODO: See TODOs about policy centralization.
-	t.Skip("Disabled until policies are centralized and evaluated in the features discovery")
-	testCase(t, func(c *testContext) {
-		tools.Register(&TestToolsProvider{
-			tools.BasicToolsProvider{
-				BasicToolsAttributes: tools.BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
-				},
+	s.T().Skip("Disabled until policies are centralized and evaluated in the features discovery")
+	tools.Register(&TestToolsProvider{
+		tools.BasicToolsProvider{
+			BasicToolsAttributes: tools.BasicToolsAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
 			},
-			TestProvider{Available: true},
-		})
-		structuredPolicies := policies.Policies{
-			Tools: map[string]any{
-				"provider-available": map[string]any{
-					"enabled": false,
-				},
+		},
+		TestProvider{Available: true},
+	})
+	structuredPolicies := policies.Policies{
+		Tools: map[string]any{
+			"provider-available": map[string]any{
+				"enabled": false,
 			},
-		}
-		features := Discover(config.New(), &structuredPolicies)
-		t.Run("ToolsNotAvailable is set to available AND disabled in policies providers", func(t *testing.T) {
-			assert.Len(t, features.Tools, 0, "expected no not available tools provider to be returned")
-			assert.Len(t, features.ToolsNotAvailable, 1, "expected one tool provider to be returned")
-			assert.Equal(t, "provider-available", features.ToolsNotAvailable[0].Attributes().Name(),
-				"expected fs provider to be returned")
-		})
+		},
+	}
+	features := Discover(config.New(), &structuredPolicies)
+	s.Run("ToolsNotAvailable is set to available AND disabled in policies providers", func() {
+		s.Len(features.Tools, 0, "expected no not available tools provider to be returned")
+		s.Len(features.ToolsNotAvailable, 1, "expected one tool provider to be returned")
+		s.Equal("provider-available", features.ToolsNotAvailable[0].Attributes().Name(),
+			"expected fs provider to be returned")
 	})
 }
 
-func TestDiscoverMarshal(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "inference-provider-available", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
-				IsAvailableReason: "conditions met",
-				ProviderModels:    []string{"model-1"},
+func (s *DiscoverTestSuite) TestDiscoverToJSON() {
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "inference-provider-available", FeatureDescription: "Test Provider"},
+				LocalAttr:              true,
 			},
-			TestProvider{Available: true},
-		})
-		inference.Register(&TestInferenceProvider{
-			inference.BasicInferenceProvider{
-				BasicInferenceAttributes: inference.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "inference-provider-unavailable", FeatureDescription: "Test Provider"},
-					LocalAttr:              false,
-					PublicAttr:             true,
-				},
-				IsAvailableReason: "conditions NOT met",
+			IsAvailableReason: "conditions met",
+			ProviderModels:    []string{"model-1"},
+		},
+		TestProvider{Available: true},
+	})
+	inference.Register(&TestInferenceProvider{
+		inference.BasicInferenceProvider{
+			BasicInferenceAttributes: inference.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "inference-provider-unavailable", FeatureDescription: "Test Provider"},
+				LocalAttr:              false,
+				PublicAttr:             true,
 			},
-			TestProvider{Available: false},
-		})
-		tools.Register(&TestToolsProvider{
-			tools.BasicToolsProvider{
-				BasicToolsAttributes: tools.BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "tools-provider-available", FeatureDescription: "Test Provider"},
-				},
-				IsAvailableReason: "tools conditions met",
+			IsAvailableReason: "conditions NOT met",
+		},
+		TestProvider{Available: false},
+	})
+	tools.Register(&TestToolsProvider{
+		tools.BasicToolsProvider{
+			BasicToolsAttributes: tools.BasicToolsAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "tools-provider-available", FeatureDescription: "Test Provider"},
 			},
-			TestProvider{Available: true},
-		})
-		features := Discover(config.New(), nil)
-		bytes, err := json.Marshal(features)
-		t.Run("Marshalling returns no error", func(t *testing.T) {
-			assert.Nil(t, err, "expected no error when marshalling inferences")
-		})
-		t.Run("Marshalling returns expected JSON", func(t *testing.T) {
-			assert.JSONEq(t, `{`+
-				`"inference":{"description":"Test Provider","local":true,"models":["model-1"],"name":"inference-provider-available","public":false,"reason":"conditions met"},`+
-				`"inferences":[{"description":"Test Provider","local":true,"models":["model-1"],"name":"inference-provider-available","public":false,"reason":"conditions met"}],`+
-				`"inferencesNotAvailable":[{"description":"Test Provider","local":false,"models":null,"name":"inference-provider-unavailable","public":true,"reason":"conditions NOT met"}],`+
-				`"tools":[{"description":"Test Provider","name":"tools-provider-available","reason":"tools conditions met"}],`+
-				`"toolsNotAvailable":null}`,
-				string(bytes),
-				"expected JSON to match the expected format")
-		})
+			IsAvailableReason: "tools conditions met",
+		},
+		TestProvider{Available: true},
+	})
+	features := Discover(config.New(), nil)
+	jsonString, err := features.ToJSON()
+	s.Run("Marshalling returns no error", func() {
+		s.Nil(err, "expected no error when marshalling inferences")
+	})
+	s.Run("Marshalling returns expected JSON", func() {
+		s.JSONEq(`{`+
+			`"inference":{"description":"Test Provider","local":true,"models":["model-1"],"name":"inference-provider-available","public":false,"reason":"conditions met"},`+
+			`"inferences":[{"description":"Test Provider","local":true,"models":["model-1"],"name":"inference-provider-available","public":false,"reason":"conditions met"}],`+
+			`"inferencesNotAvailable":[{"description":"Test Provider","local":false,"models":null,"name":"inference-provider-unavailable","public":true,"reason":"conditions NOT met"}],`+
+			`"tools":[{"description":"Test Provider","name":"tools-provider-available","reason":"tools conditions met"}],`+
+			`"toolsNotAvailable":null}`,
+			jsonString,
+			"expected JSON to match the expected format")
 	})
 }
 
-func TestGetDefaultPolicies(t *testing.T) {
+func (s *DiscoverTestSuite) TestGetDefaultPolicies() {
 	// TODO: See TODOs about policy centralization.
-	t.Skip("Disabled until policies are centralized and evaluated in the features discovery")
-	testCase(t, func(c *testContext) {
-		tools.Register(&fs.Provider{})
-		tools.Register(&kubernetes.Provider{})
-		policies := GetDefaultPolicies()
-		fmt.Printf("policies: %+v\n", policies)
-		t.Run("GetDefaultPolicies returns expected policies", func(t *testing.T) {
-			fsPolicies := policies["tools"].(map[string]any)["fs"]
-			assert.Equal(t, map[string]any{
-				"enabled":   false,
-				"read-only": false,
-			}, fsPolicies, "expected the fs policy to be returned")
+	s.T().Skip("Disabled until policies are centralized and evaluated in the features discovery")
+	tools.Register(&fs.Provider{})
+	tools.Register(&kubernetes.Provider{})
+	policies := GetDefaultPolicies()
+	fmt.Printf("policies: %+v\n", policies)
+	s.Run("GetDefaultPolicies returns expected policies", func() {
+		fsPolicies := policies["tools"].(map[string]any)["fs"]
+		s.Equal(map[string]any{
+			"enabled":   false,
+			"read-only": false,
+		}, fsPolicies, "expected the fs policy to be returned")
 
-			kubernetesPolicies := policies["tools"].(map[string]any)["kubernetes"]
-			assert.Equal(t, map[string]any{
-				"enabled":             false,
-				"read-only":           false,
-				"disable-destructive": false,
-			}, kubernetesPolicies, "expected the kubernetes policy to be returned")
-		})
+		kubernetesPolicies := policies["tools"].(map[string]any)["kubernetes"]
+		s.Equal(map[string]any{
+			"enabled":             false,
+			"read-only":           false,
+			"disable-destructive": false,
+		}, kubernetesPolicies, "expected the kubernetes policy to be returned")
 	})
+}
+
+func TestDiscover(t *testing.T) {
+	suite.Run(t, new(DiscoverTestSuite))
 }


### PR DESCRIPTION
- Different output types should be centralized in the features package
- Refactored tests to use testify