### PR TITLE
feat: output config for Cursor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 toolchain go1.24.6
 
 require (
+	github.com/adrg/xdg v0.5.3
 	github.com/charmbracelet/bubbles/v2 v2.0.0-beta.1.0.20250716191546-1e2ffbbcf5c5
 	github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.4.0.20250813213544-5cc219db8892
 	github.com/charmbracelet/glamour/v2 v2.0.0-20250811143442-a27abb32f018

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
 github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=

--- a/pkg/api/mcp-config.go
+++ b/pkg/api/mcp-config.go
@@ -1,0 +1,9 @@
+package api
+
+// MCPConfig is the interface for MCP config providers (editors supporintg MCP servers configured in a file)
+type MCPConfig interface {
+	// GetFile returns the path to the MCP config file
+	GetFile() string
+	// GetConfig returns the MCP config for the given tools in format expected by the editor
+	GetConfig(tools []ToolsProvider) ([]byte, error)
+}

--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -13,6 +13,7 @@ import (
 type ToolsProvider interface {
 	Feature[ToolsAttributes]
 	GetTools(ctx context.Context, cfg *config.Config) ([]*Tool, error)
+	GetMcpSettings() *McpSettings
 }
 
 type ToolsAttributes interface {

--- a/pkg/cmd/discover_test.go
+++ b/pkg/cmd/discover_test.go
@@ -101,6 +101,33 @@ func (s *DiscoverTestSuite) TestOutputJson() {
 	})
 }
 
+func (s *DiscoverTestSuite) TestMcpConfigUnknownEditor() {
+	s.rootCmd.SetArgs([]string{"discover", "--mcp-config", "unknown"})
+	output, err := captureOutput(s.rootCmd.Execute)
+	s.Run("Returns an error", func() {
+		s.Empty(output, "Expected empty output")
+		s.NotEmpty(err, "Expected error")
+	})
+}
+
+func (s *DiscoverTestSuite) TestMcpConfigNoValue() {
+	s.rootCmd.SetArgs([]string{"discover", "--mcp-config"})
+	output, err := captureOutput(s.rootCmd.Execute)
+	s.Run("Returns an error", func() {
+		s.Empty(output, "Expected empty output")
+		s.NotEmpty(err, "Expected error")
+	})
+}
+
+func (s *DiscoverTestSuite) TestMcpConfigEmptyValue() {
+	s.rootCmd.SetArgs([]string{"discover", "--mcp-config", ""})
+	output, err := captureOutput(s.rootCmd.Execute)
+	s.Run("Returns an error", func() {
+		s.Empty(output, "Expected empty output")
+		s.NotEmpty(err, "Expected error")
+	})
+}
+
 func TestDiscover(t *testing.T) {
 	suite.Run(t, new(DiscoverTestSuite))
 }

--- a/pkg/mcp-config/cursor/cursor.go
+++ b/pkg/mcp-config/cursor/cursor.go
@@ -1,0 +1,64 @@
+package cursor
+
+import (
+	"encoding/json"
+	"path"
+	"strings"
+
+	"github.com/adrg/xdg"
+	"github.com/manusa/ai-cli/pkg/api"
+)
+
+type CursorMcpConfigFile struct {
+	McpServers map[string]any `json:"mcpServers"`
+}
+
+type StdioServerConfig struct {
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+type RemoteServerConfig struct {
+	Url string `json:"url,omitempty"`
+	/**
+	 * Optional HTTP headers to include with every request to this server (e.g. for authentication).
+	 * The keys are header names and the values are header values.
+	 */
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type CursorMcpConfig struct{}
+
+func (p *CursorMcpConfig) GetFile() string {
+	return path.Join(xdg.Home, ".cursor", "mcp.json")
+}
+
+func (p *CursorMcpConfig) GetConfig(tools []api.ToolsProvider) ([]byte, error) {
+	result := CursorMcpConfigFile{
+		McpServers: make(map[string]any),
+	}
+	for _, tool := range tools {
+		mcpSettings := tool.GetMcpSettings()
+		if mcpSettings == nil {
+			continue
+		}
+		if mcpSettings.Type == api.McpTypeStdio {
+			result.McpServers[tool.Attributes().Name()] = StdioServerConfig{
+				Command: mcpSettings.Command,
+				Args:    mcpSettings.Args,
+				Env:     toEnvMap(mcpSettings.Env),
+			}
+		}
+	}
+	return json.MarshalIndent(result, "", "  ")
+}
+
+func toEnvMap(envArray []string) map[string]string {
+	result := make(map[string]string, len(envArray))
+	for _, env := range envArray {
+		key, value, _ := strings.Cut(env, "=")
+		result[key] = value
+	}
+	return result
+}

--- a/pkg/mcp-config/cursor/cursor_test.go
+++ b/pkg/mcp-config/cursor/cursor_test.go
@@ -1,0 +1,85 @@
+package cursor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/manusa/ai-cli/pkg/tools"
+	"github.com/stretchr/testify/suite"
+)
+
+type CursorTestSuite struct {
+	suite.Suite
+}
+
+type TestToolsProvider struct {
+	mcpSettings *api.McpSettings
+}
+
+func (p *TestToolsProvider) GetMcpSettings() *api.McpSettings {
+	return p.mcpSettings
+}
+
+func (p *TestToolsProvider) Attributes() api.ToolsAttributes {
+	return &tools.BasicToolsProvider{
+		BasicToolsAttributes: tools.BasicToolsAttributes{
+			BasicFeatureAttributes: api.BasicFeatureAttributes{
+				FeatureName:        "testtool",
+				FeatureDescription: "A test tool",
+			},
+		},
+	}
+}
+
+func (p *TestToolsProvider) GetDefaultPolicies() map[string]any {
+	return nil
+}
+
+func (p *TestToolsProvider) GetTools(ctx context.Context, cfg *config.Config) ([]*api.Tool, error) {
+	return nil, nil
+}
+
+func (p *TestToolsProvider) IsAvailable(_ *config.Config, _ any) bool {
+	return true
+}
+
+func (p *TestToolsProvider) Reason() string {
+	return ""
+}
+
+func (s *CursorTestSuite) SetupTest() {}
+
+func TestCursor(t *testing.T) {
+	suite.Run(t, new(CursorTestSuite))
+}
+
+func (s *CursorTestSuite) TestGetConfigEmpty() {
+	s.Run("GetConfig returns an empty config with no tools", func() {
+		provider := &CursorMcpConfig{}
+		tools := []api.ToolsProvider{}
+		result, err := provider.GetConfig(tools)
+		s.NoError(err)
+		s.JSONEq(string(result), `{ "mcpServers": {} }`)
+	})
+}
+
+func (s *CursorTestSuite) TestGetConfigWithTools() {
+	s.Run("GetConfig returns a config with the tools", func() {
+		provider := &CursorMcpConfig{}
+		tools := []api.ToolsProvider{
+			&TestToolsProvider{
+				mcpSettings: &api.McpSettings{
+					Type:    api.McpTypeStdio,
+					Command: "mycmd",
+					Args:    []string{"arg1", "arg2"},
+					Env:     []string{"ENV=value"},
+				},
+			},
+		}
+		result, err := provider.GetConfig(tools)
+		s.NoError(err)
+		s.JSONEq(string(result), `{ "mcpServers": { "testtool": { "command": "mycmd", "args": ["arg1", "arg2"], "env": { "ENV": "value" } } } }`)
+	})
+}

--- a/pkg/mcp-config/mcp-config.go
+++ b/pkg/mcp-config/mcp-config.go
@@ -1,0 +1,44 @@
+package mcpconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+)
+
+func Save(provider api.MCPConfig, tools []api.ToolsProvider) error {
+	content, err := provider.GetConfig(tools)
+	if err != nil {
+		return err
+	}
+	configFile := provider.GetFile()
+	if _, err := config.FileSystem.Stat(configFile); err == nil {
+		// file exists, output config to stdout
+		// and message to stderr
+		fmt.Fprintf(os.Stderr, "MCP config file %s already exists, outputting config to stdout\n", configFile)
+		_, err := fmt.Println(string(content))
+		return err
+	} else {
+		// file does not exist, create it
+		err = config.FileSystem.MkdirAll(filepath.Dir(configFile), 0755)
+		if err != nil {
+			return err
+		}
+		file, err := config.FileSystem.Create(configFile)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = file.Close()
+		}()
+		_, err = file.Write(content)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("MCP config file %s has been created\n", configFile)
+	}
+	return nil
+}

--- a/pkg/mcp-config/mcp-config_test.go
+++ b/pkg/mcp-config/mcp-config_test.go
@@ -1,0 +1,116 @@
+package mcpconfig
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+)
+
+type McpConfigTestSuite struct {
+	suite.Suite
+}
+
+func (s *McpConfigTestSuite) SetupTest() {
+	config.FileSystem = afero.NewMemMapFs()
+}
+
+func (s *McpConfigTestSuite) TearDownTest() {}
+
+type TestProvider struct{}
+
+func (p *TestProvider) GetFile() string {
+	return "/path/to/config"
+}
+
+func (p *TestProvider) GetConfig(tools []api.ToolsProvider) ([]byte, error) {
+	return []byte("a config"), nil
+}
+
+func (s *McpConfigTestSuite) TestSaveNewFile() {
+	s.Run("Save creates a new file if it does not exist", func() {
+		out, errOut, err := captureStdouts(func() error { return Save(&TestProvider{}, nil) })
+		s.NoError(err)
+
+		if _, err := config.FileSystem.Stat("/path/to/config"); err != nil && !os.IsNotExist(err) {
+			s.Fail("file does not exist")
+		}
+		content, err := readFile(config.FileSystem, "/path/to/config")
+		s.NoError(err)
+		s.Equal("a config", string(content))
+		s.Equal("MCP config file /path/to/config has been created\n", out)
+		s.Equal("", errOut)
+	})
+}
+
+func (s *McpConfigTestSuite) TestSaveStdout() {
+	s.Run("Save outputs to stdoutif config file exists", func() {
+		err := createFile(config.FileSystem, "/path/to/config", "content before")
+		s.NoError(err)
+		out, errOut, err := captureStdouts(func() error { return Save(&TestProvider{}, nil) })
+		s.NoError(err)
+		if _, err := config.FileSystem.Stat("/path/to/config"); err != nil && !os.IsNotExist(err) {
+			s.Fail("file does not exist")
+		}
+		content, err := readFile(config.FileSystem, "/path/to/config")
+		s.NoError(err)
+		// content should not have changed
+		s.Equal("content before", string(content))
+		s.Equal("MCP config file /path/to/config already exists, outputting config to stdout\n", errOut)
+		s.Equal("a config\n", out)
+	})
+}
+func TestMcpConfig(t *testing.T) {
+	suite.Run(t, new(McpConfigTestSuite))
+}
+
+func createFile(fs afero.Fs, path string, content string) error {
+	err := fs.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return err
+	}
+	file, err := fs.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	_, err = file.Write([]byte(content))
+	return err
+}
+
+func readFile(fs afero.Fs, path string) ([]byte, error) {
+	file, err := fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	return io.ReadAll(file)
+}
+
+func captureStdouts(f func() error) (string, string, error) {
+	originalOut := os.Stdout
+	originalErr := os.Stderr
+	defer func() {
+		os.Stdout = originalOut
+		os.Stderr = originalErr
+	}()
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+	err := f()
+	_ = wOut.Close()
+	_ = wErr.Close()
+	outBytes, _ := io.ReadAll(rOut)
+	errBytes, _ := io.ReadAll(rErr)
+	return string(outBytes), string(errBytes), err
+}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -26,6 +26,10 @@ func (p *BasicToolsProvider) Reason() string {
 	return p.IsAvailableReason
 }
 
+func (p *BasicToolsProvider) GetMcpSettings() *api.McpSettings {
+	return p.McpSettings
+}
+
 type BasicToolsAttributes struct {
 	api.BasicFeatureAttributes
 }


### PR DESCRIPTION
When the `~/.cursor/mcp.json` file already exists:

```
$ ai-cli discover --mcp-config cursor
[STDERR] MCP config file /Users/User/.cursor/mcp.json already exists, outputting config to stdout
{
  "mcpServers": {
    "kubernetes": {
      "command": "uvx",
      "args": [
        "kubernetes-mcp-server@latest"
      ]
    }
  }
}
```

When the file does not exist:
```
$ ai-cli discover --mcp-config cursor
MCP config file /Users/User/.cursor/mcp.json has been created
```


For the moment, only `cursor` output is supported, and only stdio mcp servers are supported for cursor
 
For the moment, the file is not overwritten if it exists. We can imagine for follow-up PRs to merge the existing file with the new config, for example by prefixing the entries added by the CLI with `ai-cli-` to be able to recognize them.


Part of #50