### PR TITLE
feat(feature): misc refactors on features

### DIFF
--- a/pkg/api/features.go
+++ b/pkg/api/features.go
@@ -1,11 +1,20 @@
 package api
 
-import "github.com/manusa/ai-cli/pkg/config"
+import (
+	"cmp"
+
+	"github.com/manusa/ai-cli/pkg/config"
+)
 
 type Feature[a FeatureAttributes] interface {
 	Attributes() a
-	// IsAvailable Returns true if the feature is available based on the user configuration and policies
-	IsAvailable(cfg *config.Config, policies any) bool
+	// Initialize Performs the discovery and initialization of the feature based on the user configuration and policies
+	// Populates the internal state of the feature and its availability
+	// TODO: Policies should not be treated in a per-feature way but rather in a global way
+	// TODO: for each feature proider (inferences, tools, etc.) this should be handled in the Initialize function
+	Initialize(cfg *config.Config, policies any)
+	// IsAvailable Returns true if the feature is available
+	IsAvailable() bool
 	// Reason provides the reason why the feature is or is not available
 	Reason() string
 	GetDefaultPolicies() map[string]any
@@ -30,4 +39,8 @@ func (a *BasicFeatureAttributes) Name() string {
 
 func (a *BasicFeatureAttributes) Description() string {
 	return a.FeatureDescription
+}
+
+func FeatureSorter[A FeatureAttributes, F Feature[A]](a F, b F) int {
+	return cmp.Compare(a.Attributes().Name(), b.Attributes().Name())
 }

--- a/pkg/api/inference.go
+++ b/pkg/api/inference.go
@@ -25,12 +25,17 @@ type InferenceAttributes interface {
 type BasicInferenceProvider struct {
 	InferenceProvider `json:"-"`
 	BasicInferenceAttributes
+	Available         bool     `json:"-"`
 	IsAvailableReason string   `json:"reason"`
 	ProviderModels    []string `json:"models"`
 }
 
 func (p *BasicInferenceProvider) Attributes() InferenceAttributes {
 	return &p.BasicInferenceAttributes
+}
+
+func (p *BasicInferenceProvider) IsAvailable() bool {
+	return p.Available
 }
 
 func (p *BasicInferenceProvider) Reason() string {

--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -20,6 +20,34 @@ type ToolsAttributes interface {
 	FeatureAttributes
 }
 
+type BasicToolsProvider struct {
+	ToolsProvider `json:"-"`
+	BasicToolsAttributes
+	Available         bool         `json:"-"`
+	IsAvailableReason string       `json:"reason"`
+	McpSettings       *McpSettings `json:"mcp_settings,omitempty"`
+}
+
+func (p *BasicToolsProvider) Attributes() ToolsAttributes {
+	return &p.BasicToolsAttributes
+}
+
+func (p *BasicToolsProvider) IsAvailable() bool {
+	return p.Available
+}
+
+func (p *BasicToolsProvider) Reason() string {
+	return p.IsAvailableReason
+}
+
+func (p *BasicToolsProvider) GetMcpSettings() *McpSettings {
+	return p.McpSettings
+}
+
+type BasicToolsAttributes struct {
+	BasicFeatureAttributes
+}
+
 type Tool struct {
 	Name        string
 	Description string

--- a/pkg/inference/discover.go
+++ b/pkg/inference/discover.go
@@ -2,8 +2,8 @@ package inference
 
 import (
 	"fmt"
+	"maps"
 	"slices"
-	"strings"
 
 	"github.com/manusa/ai-cli/pkg/api"
 	"github.com/manusa/ai-cli/pkg/config"
@@ -27,21 +27,10 @@ func Clear() {
 	providers = map[string]api.InferenceProvider{}
 }
 
-// Discover the available and not available inference providers based on the user preferences
-func Discover(cfg *config.Config, policies map[string]any) (availableInferences []api.InferenceProvider, notAvailableInferences []api.InferenceProvider) {
-	availableInferences, notAvailableInferences = []api.InferenceProvider{}, []api.InferenceProvider{}
+// Initialize initializes the registered providers based on the user preferences
+func Initialize(cfg *config.Config, policies map[string]any) []api.InferenceProvider {
 	for _, provider := range providers {
-		if provider.IsAvailable(cfg, policies) {
-			availableInferences = append(availableInferences, provider)
-		} else {
-			notAvailableInferences = append(notAvailableInferences, provider)
-		}
+		provider.Initialize(cfg, policies[provider.Attributes().Name()])
 	}
-	slices.SortFunc(availableInferences, func(a, b api.InferenceProvider) int {
-		return strings.Compare(a.Attributes().Name(), b.Attributes().Name())
-	})
-	slices.SortFunc(notAvailableInferences, func(a, b api.InferenceProvider) int {
-		return strings.Compare(a.Attributes().Name(), b.Attributes().Name())
-	})
-	return availableInferences, notAvailableInferences
+	return slices.Collect(maps.Values(providers))
 }

--- a/pkg/inference/discover_test.go
+++ b/pkg/inference/discover_test.go
@@ -3,106 +3,58 @@ package inference
 import (
 	"testing"
 
-	"github.com/manusa/ai-cli/pkg/api"
-	"github.com/manusa/ai-cli/pkg/config"
 	"github.com/manusa/ai-cli/pkg/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-type testContext struct {
+type DiscoverTestSuite struct {
+	suite.Suite
 }
 
-func (c *testContext) beforeEach(t *testing.T) {
-	t.Helper()
+func (s *DiscoverTestSuite) SetupTest() {
 	Clear()
 }
 
-func (c *testContext) afterEach(t *testing.T) {
-	t.Helper()
-}
-
-func testCase(t *testing.T, test func(c *testContext)) {
-	testCaseWithContext(t, &testContext{}, test)
-}
-
-func testCaseWithContext(t *testing.T, ctx *testContext, test func(c *testContext)) {
-	ctx.beforeEach(t)
-	t.Cleanup(func() { ctx.afterEach(t) })
-	test(ctx)
-}
-
-func TestRegister(t *testing.T) {
+func (s *DiscoverTestSuite) TestRegister() {
 	// Registering a provider should add it to the providers map
-	testCase(t, func(c *testContext) {
-		t.Run("Registering a provider adds it to the providers map", func(t *testing.T) {
-			Register(&test.InferenceProvider{
-				BasicInferenceProvider: api.BasicInferenceProvider{
-					BasicInferenceAttributes: api.BasicInferenceAttributes{
-						BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "testProvider", FeatureDescription: "Test Provider"},
-						LocalAttr:              true,
-					},
-				},
-				Available: true,
-			})
-			assert.Contains(t, providers, "testProvider",
-				"expected provider %s to be registered in the providers %v", "testProvider", providers)
-		})
+	s.Run("Registering a provider adds it to the providers map", func() {
+		Register(test.NewInferenceProvider(
+			"testProvider",
+			test.WithInferenceAvailable(),
+			test.WithInferenceLocal(),
+		))
+		s.Contains(providers, "testProvider",
+			"expected provider %s to be registered in the providers %v", "testProvider", providers)
 	})
 	// Registering a provider with the same name should panic
-	testCase(t, func(c *testContext) {
-		t.Run("Registering a provider with the same name panics", func(t *testing.T) {
-			provider := &test.InferenceProvider{
-				BasicInferenceProvider: api.BasicInferenceProvider{
-					BasicInferenceAttributes: api.BasicInferenceAttributes{
-						BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "duplicateProvider", FeatureDescription: "Test Provider"},
-						LocalAttr:              true,
-					},
-				},
-				Available: true,
-			}
+	s.Run("Registering a provider with the same name panics", func() {
+		provider := test.NewInferenceProvider(
+			"duplicateProvider",
+			test.WithInferenceAvailable(),
+			test.WithInferenceLocal(),
+		)
+		Register(provider)
+		s.Panics(func() {
 			Register(provider)
-			assert.Panics(t, func() {
-				Register(provider)
-			}, "expected panic when registering a provider with the same name")
-		})
+		}, "expected panic when registering a provider with the same name")
+	})
+	// Registering a nil provider should panic
+	s.Run("Registering a nil provider panics", func() {
+		s.Panics(func() {
+			Register(nil)
+		}, "expected panic when registering a nil provider")
+	})
+}
+
+func (s *DiscoverTestSuite) TestInitialize() {
+	provider := test.NewInferenceProvider("the-provider")
+	Register(provider)
+	Initialize(nil, nil)
+	s.Run("Initialize calls Initialize on all providers", func() {
+		s.True(provider.Initialized, "expected provider to be initialized")
 	})
 }
 
 func TestDiscover(t *testing.T) {
-	// With no providers registered, it should returns empty
-	testCase(t, func(c *testContext) {
-		t.Run("With no providers registered returns empty", func(t *testing.T) {
-			availableInferences, notAvailableInferences := Discover(config.New(), nil)
-			assert.Empty(t, availableInferences, "expected no inferences to be returned when no providers are registered")
-			assert.Empty(t, notAvailableInferences, "expected no not available inferences to be returned when no providers are registered")
-		})
-	})
-	// With one available provider, it should return that provider
-	testCase(t, func(c *testContext) {
-		Register(&test.InferenceProvider{
-			BasicInferenceProvider: api.BasicInferenceProvider{
-				BasicInferenceAttributes: api.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-available", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
-			},
-			Available: true,
-		})
-		Register(&test.InferenceProvider{
-			BasicInferenceProvider: api.BasicInferenceProvider{
-				BasicInferenceAttributes: api.BasicInferenceAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{FeatureName: "provider-unavailable", FeatureDescription: "Test Provider"},
-					LocalAttr:              true,
-				},
-			},
-			Available: false,
-		})
-		availableInferences, notAvailableInferences := Discover(config.New(), nil)
-		t.Run("With one available provider returns that provider", func(t *testing.T) {
-			assert.Len(t, availableInferences, 1, "expected one available provider to be registered")
-			assert.Equal(t, "provider-available", availableInferences[0].Attributes().Name(),
-				"expected the available provider to be returned")
-			assert.Len(t, notAvailableInferences, 1, "expected one not available provider")
-		})
-	})
+	suite.Run(t, new(DiscoverTestSuite))
 }

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -18,15 +18,14 @@ type Provider struct {
 
 var _ api.InferenceProvider = &Provider{}
 
-func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
-	available := cfg.GoogleApiKey != ""
-	if available {
+func (p *Provider) Initialize(cfg *config.Config, _ any) {
+	p.Available = cfg.GoogleApiKey != ""
+	if p.Available {
 		p.IsAvailableReason = "GEMINI_API_KEY is set"
 		p.ProviderModels = []string{"gemini-2.0-flash"}
 	} else {
 		p.IsAvailableReason = "GEMINI_API_KEY is not set"
 	}
-	return available
 }
 
 func (p *Provider) GetInference(ctx context.Context, cfg *config.Config) (model.ToolCallingChatModel, error) {

--- a/pkg/inference/lmstudio/lmstudio.go
+++ b/pkg/inference/lmstudio/lmstudio.go
@@ -50,16 +50,16 @@ func (p *Provider) GetModels(_ context.Context, _ *config.Config) ([]string, err
 	return modelsNames, nil
 }
 
-func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
+func (p *Provider) Initialize(cfg *config.Config, _ any) {
 	baseURL := p.baseURL()
 	resp, err := http.Get(baseURL + "/v1/models")
 	if err != nil {
 		p.IsAvailableReason = fmt.Sprintf("%s is not accessible", baseURL)
-		return false
+		return
 	}
 	_ = resp.Body.Close()
-	available := resp.StatusCode == http.StatusOK
-	if available {
+	p.Available = resp.StatusCode == http.StatusOK
+	if p.Available {
 		p.IsAvailableReason = fmt.Sprintf("LM Studio is accessible at %s", baseURL)
 		models, err := p.GetModels(context.Background(), cfg)
 		if err == nil {
@@ -68,7 +68,7 @@ func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
 	} else {
 		p.IsAvailableReason = fmt.Sprintf("LM Studio is not accessible at %s", baseURL)
 	}
-	return available
+
 }
 
 func (p *Provider) GetInference(ctx context.Context, cfg *config.Config) (model.ToolCallingChatModel, error) {

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -63,7 +63,7 @@ func (p *Provider) GetModels(_ context.Context, _ *config.Config) ([]string, err
 	return modelsNames, nil
 }
 
-func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
+func (p *Provider) Initialize(cfg *config.Config, _ any) {
 	baseURL := p.baseURL()
 	isBaseURLConfigured := p.isBaseURLConfigured()
 	resp, err := http.Get(baseURL + "/v1/models")
@@ -73,11 +73,11 @@ func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
 		} else {
 			p.IsAvailableReason = fmt.Sprintf("%s is not accessible", baseURL)
 		}
-		return false
+		return
 	}
 	_ = resp.Body.Close()
-	available := resp.StatusCode == http.StatusOK
-	if available {
+	p.Available = resp.StatusCode == http.StatusOK
+	if p.Available {
 		if isBaseURLConfigured {
 			p.IsAvailableReason = fmt.Sprintf("ollama is accessible at %s defined by the %s environment variable", baseURL, ollamaHostEnvVar)
 		} else {
@@ -94,7 +94,6 @@ func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
 			p.IsAvailableReason = fmt.Sprintf("ollama is not accessible at %s", baseURL)
 		}
 	}
-	return available
 }
 
 func (p *Provider) GetInference(ctx context.Context, cfg *config.Config) (model.ToolCallingChatModel, error) {

--- a/pkg/inference/ramalama/ramalama.go
+++ b/pkg/inference/ramalama/ramalama.go
@@ -44,21 +44,21 @@ func (p *Provider) GetModels(_ context.Context, _ *config.Config) ([]string, err
 	return models, nil
 }
 
-func (p *Provider) IsAvailable(cfg *config.Config, policies any) bool {
+func (p *Provider) Initialize(cfg *config.Config, _ any) {
 	_, err := exec.LookPath(p.getRamalamaBinaryName())
 	if err != nil {
 		p.IsAvailableReason = "ramalama is not installed"
-		return false
+		return
 	}
 	models, err := p.GetModels(context.Background(), cfg)
 	if err != nil || len(models) == 0 {
 		p.IsAvailableReason = "ramalama is installed but no models are served"
-		return false
+		return
 	}
 	p.ProviderModels = models
 
+	p.Available = true
 	p.IsAvailableReason = "ramalama is serving models"
-	return true
 }
 
 func (p *Provider) GetInference(ctx context.Context, cfg *config.Config) (model.ToolCallingChatModel, error) {

--- a/pkg/mcp-config/cursor/cursor_test.go
+++ b/pkg/mcp-config/cursor/cursor_test.go
@@ -1,12 +1,10 @@
 package cursor
 
 import (
-	"context"
 	"testing"
 
 	"github.com/manusa/ai-cli/pkg/api"
-	"github.com/manusa/ai-cli/pkg/config"
-	"github.com/manusa/ai-cli/pkg/tools"
+	"github.com/manusa/ai-cli/pkg/test"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -15,6 +13,7 @@ type CursorTestSuite struct {
 }
 
 type TestToolsProvider struct {
+	test.ToolsProvider
 	mcpSettings *api.McpSettings
 }
 
@@ -22,31 +21,8 @@ func (p *TestToolsProvider) GetMcpSettings() *api.McpSettings {
 	return p.mcpSettings
 }
 
-func (p *TestToolsProvider) Attributes() api.ToolsAttributes {
-	return &tools.BasicToolsProvider{
-		BasicToolsAttributes: tools.BasicToolsAttributes{
-			BasicFeatureAttributes: api.BasicFeatureAttributes{
-				FeatureName:        "testtool",
-				FeatureDescription: "A test tool",
-			},
-		},
-	}
-}
-
 func (p *TestToolsProvider) GetDefaultPolicies() map[string]any {
 	return nil
-}
-
-func (p *TestToolsProvider) GetTools(ctx context.Context, cfg *config.Config) ([]*api.Tool, error) {
-	return nil, nil
-}
-
-func (p *TestToolsProvider) IsAvailable(_ *config.Config, _ any) bool {
-	return true
-}
-
-func (p *TestToolsProvider) Reason() string {
-	return ""
 }
 
 func (s *CursorTestSuite) SetupTest() {}
@@ -58,7 +34,7 @@ func TestCursor(t *testing.T) {
 func (s *CursorTestSuite) TestGetConfigEmpty() {
 	s.Run("GetConfig returns an empty config with no tools", func() {
 		provider := &CursorMcpConfig{}
-		tools := []api.ToolsProvider{}
+		var tools []api.ToolsProvider
 		result, err := provider.GetConfig(tools)
 		s.NoError(err)
 		s.JSONEq(string(result), `{ "mcpServers": {} }`)
@@ -70,6 +46,16 @@ func (s *CursorTestSuite) TestGetConfigWithTools() {
 		provider := &CursorMcpConfig{}
 		tools := []api.ToolsProvider{
 			&TestToolsProvider{
+				ToolsProvider: test.ToolsProvider{
+					BasicToolsProvider: api.BasicToolsProvider{
+						BasicToolsAttributes: api.BasicToolsAttributes{
+							BasicFeatureAttributes: api.BasicFeatureAttributes{
+								FeatureName:        "testtool",
+								FeatureDescription: "Test Tool",
+							},
+						},
+					},
+				},
 				mcpSettings: &api.McpSettings{
 					Type:    api.McpTypeStdio,
 					Command: "mycmd",

--- a/pkg/test/inference.go
+++ b/pkg/test/inference.go
@@ -8,14 +8,50 @@ import (
 	"github.com/manusa/ai-cli/pkg/config"
 )
 
-type InferenceProvider struct {
-	api.BasicInferenceProvider
-	Available bool                       `json:"-"`
-	Llm       model.ToolCallingChatModel `json:"-"`
+type InferenceProviderOption func(*InferenceProvider)
+
+func WithInferenceAvailable() InferenceProviderOption {
+	return func(i *InferenceProvider) {
+		i.Available = true
+	}
 }
 
-func (i *InferenceProvider) IsAvailable(_ *config.Config, _ any) bool {
-	return i.Available
+func WithInferenceLocal() InferenceProviderOption {
+	return func(i *InferenceProvider) {
+		i.LocalAttr = true
+	}
+}
+
+func WithInferencePublic() InferenceProviderOption {
+	return func(i *InferenceProvider) {
+		i.PublicAttr = true
+	}
+}
+
+func NewInferenceProvider(name string, options ...InferenceProviderOption) *InferenceProvider {
+	p := &InferenceProvider{
+		BasicInferenceProvider: api.BasicInferenceProvider{
+			BasicInferenceAttributes: api.BasicInferenceAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{
+					FeatureName: name,
+				},
+			},
+		},
+	}
+	for _, option := range options {
+		option(p)
+	}
+	return p
+}
+
+type InferenceProvider struct {
+	api.BasicInferenceProvider
+	Initialized bool                       `json:"-"`
+	Llm         model.ToolCallingChatModel `json:"-"`
+}
+
+func (i *InferenceProvider) Initialize(_ *config.Config, _ any) {
+	i.Initialized = true
 }
 
 func (i *InferenceProvider) GetDefaultPolicies() map[string]any {

--- a/pkg/test/tools.go
+++ b/pkg/test/tools.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"context"
+
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+)
+
+type ToolsProviderOption func(*ToolsProvider)
+
+func WithToolsAvailable() ToolsProviderOption {
+	return func(i *ToolsProvider) {
+		i.Available = true
+	}
+}
+
+func NewToolsProvider(name string, options ...ToolsProviderOption) *ToolsProvider {
+	p := &ToolsProvider{
+		BasicToolsProvider: api.BasicToolsProvider{
+			BasicToolsAttributes: api.BasicToolsAttributes{
+				BasicFeatureAttributes: api.BasicFeatureAttributes{
+					FeatureName: name,
+				},
+			},
+		},
+	}
+	for _, option := range options {
+		option(p)
+	}
+	return p
+}
+
+type ToolsProvider struct {
+	api.BasicToolsProvider
+	Initialized bool           `json:"-"`
+	Tools       []*api.Tool    `json:"-"`
+	Policies    map[string]any `json:"-"`
+}
+
+func (t *ToolsProvider) Initialize(_ *config.Config, _ any) {
+	t.Initialized = true
+}
+
+func (t *ToolsProvider) GetDefaultPolicies() map[string]any {
+	return t.Policies
+}
+
+func (t *ToolsProvider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
+	return t.Tools, nil
+}

--- a/pkg/tools/discover_test.go
+++ b/pkg/tools/discover_test.go
@@ -1,214 +1,128 @@
 package tools
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/manusa/ai-cli/pkg/api"
-	"github.com/stretchr/testify/assert"
+	"github.com/manusa/ai-cli/pkg/test"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/manusa/ai-cli/pkg/config"
 )
 
-type TestProvider struct {
-	BasicToolsProvider
-	Available bool           `json:"-"`
-	Tools     []*api.Tool    `json:"-"`
-	Policies  map[string]any `json:"-"`
+type DiscoverTestSuite struct {
+	suite.Suite
 }
 
-func (t *TestProvider) IsAvailable(_ *config.Config, _ any) bool {
-	return t.Available
-}
-
-func (t *TestProvider) GetDefaultPolicies() map[string]any {
-	return t.Policies
-}
-
-func (t *TestProvider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
-	return t.Tools, nil
-}
-
-type testContext struct {
-}
-
-func (c *testContext) beforeEach(t *testing.T) {
-	t.Helper()
+func (s *DiscoverTestSuite) SetupTest() {
 	Clear()
 }
 
-func (c *testContext) afterEach(t *testing.T) {
-	t.Helper()
-}
-
-func testCase(t *testing.T, test func(c *testContext)) {
-	testCaseWithContext(t, &testContext{}, test)
-}
-
-func testCaseWithContext(t *testing.T, ctx *testContext, test func(c *testContext)) {
-	ctx.beforeEach(t)
-	t.Cleanup(func() { ctx.afterEach(t) })
-	test(ctx)
-}
-
-func TestRegister(t *testing.T) {
+func (s *DiscoverTestSuite) TestRegister() {
 	// Registering a provider should add it to the providers map
-	testCase(t, func(c *testContext) {
-		t.Run("Registering a provider adds it to the providers map", func(t *testing.T) {
-			Register(&TestProvider{
-				BasicToolsProvider: BasicToolsProvider{
-					BasicToolsAttributes: BasicToolsAttributes{
-						BasicFeatureAttributes: api.BasicFeatureAttributes{
-							FeatureName:        "testProvider",
-							FeatureDescription: "Test Provider",
-						},
+	s.Run("Registering a provider adds it to the providers map", func() {
+		Register(&test.ToolsProvider{
+			BasicToolsProvider: api.BasicToolsProvider{
+				BasicToolsAttributes: api.BasicToolsAttributes{
+					BasicFeatureAttributes: api.BasicFeatureAttributes{
+						FeatureName:        "testProvider",
+						FeatureDescription: "Test Provider",
 					},
 				},
 				Available: true,
-			})
-			assert.Contains(t, providers, "testProvider",
-				"expected provider %s to be registered in the providers %v", "testProvider", providers)
+			},
 		})
+		s.Contains(providers, "testProvider",
+			"expected provider %s to be registered in the providers %v", "testProvider", providers)
 	})
 	// Registering a provider with the same name should panic
-	testCase(t, func(c *testContext) {
-		t.Run("Registering a provider with the same name panics", func(t *testing.T) {
-			provider := &TestProvider{
-				BasicToolsProvider: BasicToolsProvider{
-					BasicToolsAttributes: BasicToolsAttributes{
-						BasicFeatureAttributes: api.BasicFeatureAttributes{
-							FeatureName:        "duplicateProvider",
-							FeatureDescription: "Test Provider",
-						},
+	s.Run("Registering a provider with the same name panics", func() {
+		provider := &test.ToolsProvider{
+			BasicToolsProvider: api.BasicToolsProvider{
+				BasicToolsAttributes: api.BasicToolsAttributes{
+					BasicFeatureAttributes: api.BasicFeatureAttributes{
+						FeatureName:        "duplicateProvider",
+						FeatureDescription: "Test Provider",
 					},
 				},
 				Available: true,
-			}
+			},
+		}
+		Register(provider)
+		s.Panics(func() {
 			Register(provider)
-			assert.Panics(t, func() {
-				Register(provider)
-			}, "expected panic when registering a provider with the same name")
-		})
+		}, "expected panic when registering a provider with the same name")
+	})
+	// Registering a nil provider should panic
+	s.Run("Registering a nil provider panics", func() {
+		s.Panics(func() {
+			Register(nil)
+		}, "expected panic when registering a nil provider")
+	})
+}
+
+func (s *DiscoverTestSuite) TestInitialize() {
+	provider := test.NewToolsProvider("the-provider")
+	Register(provider)
+	Initialize(nil, nil)
+	s.Run("Initialize calls Initialize on all providers", func() {
+		s.True(provider.Initialized, "expected provider to be initialized")
+	})
+}
+
+func (s *DiscoverTestSuite) TestMarshalling() {
+	Register(test.NewToolsProvider(
+		"provider-one",
+		test.WithToolsAvailable(),
+		func(provider *test.ToolsProvider) {
+			provider.FeatureDescription = "Test Provider"
+		},
+	))
+	Register(test.NewToolsProvider(
+		"provider-two",
+		test.WithToolsAvailable(),
+		func(provider *test.ToolsProvider) {
+			provider.FeatureDescription = "Test Provider"
+		},
+	))
+	discoveredTools := Initialize(config.New(), nil)
+	bytes, err := json.Marshal(discoveredTools)
+	s.Run("Marshalling returns no error", func() {
+		s.Nil(err, "expected no error when marshalling inferences")
+	})
+	s.Run("Marshalling returns expected JSON", func() {
+		s.JSONEq(`[{"description":"Test Provider","name":"provider-one","reason":""},{"description":"Test Provider","name":"provider-two","reason":""}]`, string(bytes),
+			"expected JSON to match the expected format")
+	})
+}
+
+func (s *DiscoverTestSuite) TestGetDefaultPolicies() {
+	Register(test.NewToolsProvider(
+		"provider-one",
+		func(provider *test.ToolsProvider) {
+			provider.Policies = map[string]any{
+				"provider-one-policy": "provider-one-policy-value",
+			}
+		},
+	))
+	Register(test.NewToolsProvider(
+		"provider-two",
+		func(provider *test.ToolsProvider) {
+			provider.Policies = map[string]any{
+				"provider-two-policy": "provider-two-policy-value",
+			}
+		},
+	))
+	s.Run("GetDefaultPolicies returns expected policies", func() {
+		policies := GetDefaultPolicies()
+		fmt.Printf("policies: %+v\n", policies)
+		s.Equal(map[string]any{"provider-one-policy": "provider-one-policy-value"}, policies["provider-one"], "expected the provider-one policy to be returned")
+		s.Equal(map[string]any{"provider-two-policy": "provider-two-policy-value"}, policies["provider-two"], "expected the provider-two policy to be returned")
 	})
 }
 
 func TestDiscover(t *testing.T) {
-	// With no providers registered, it should returns empty
-	testCase(t, func(c *testContext) {
-		t.Run("With no providers registered returns empty", func(t *testing.T) {
-			availableTools, notAvailableTools := Discover(config.New(), nil)
-			assert.Empty(t, availableTools, "expected no available tools to be returned when no providers are registered")
-			assert.Empty(t, notAvailableTools, "expected no not available tools to be returned when no providers are registered")
-		})
-	})
-	// With one available provider, it should return that provider
-	testCase(t, func(c *testContext) {
-		Register(&TestProvider{
-			BasicToolsProvider: BasicToolsProvider{
-				BasicToolsAttributes: BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{
-						FeatureName:        "provider-available",
-						FeatureDescription: "Test Provider",
-					},
-				},
-			},
-			Available: true,
-		})
-		Register(&TestProvider{
-			BasicToolsProvider: BasicToolsProvider{
-				BasicToolsAttributes: BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{
-						FeatureName:        "provider-unavailable",
-						FeatureDescription: "Test Provider",
-					},
-				},
-			},
-			Available: false,
-		})
-		availableTools, notAvailableTools := Discover(config.New(), nil)
-		t.Run("With one available provider returns that provider", func(t *testing.T) {
-			assert.Len(t, availableTools, 1, "expected one available provider to be registered")
-			assert.Equal(t, "provider-available", availableTools[0].Attributes().Name(),
-				"expected the available provider to be returned")
-			assert.Len(t, notAvailableTools, 1, "expected one not available provider to be registered")
-		})
-	})
-}
-
-func TestDiscoverMarshalling(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		Register(&TestProvider{
-			BasicToolsProvider: BasicToolsProvider{
-				BasicToolsAttributes: BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{
-						FeatureName:        "provider-one",
-						FeatureDescription: "Test Provider",
-					},
-				},
-			},
-			Available: true,
-		})
-		Register(&TestProvider{
-			BasicToolsProvider: BasicToolsProvider{
-				BasicToolsAttributes: BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{
-						FeatureName:        "provider-two",
-						FeatureDescription: "Test Provider",
-					},
-				},
-			},
-			Available: true,
-		})
-		availableTools, notAvailableTools := Discover(config.New(), nil)
-		bytes, err := json.Marshal(availableTools)
-		t.Run("Marshalling returns no error", func(t *testing.T) {
-			assert.Nil(t, err, "expected no error when marshalling inferences")
-		})
-		t.Run("Marshalling returns expected JSON", func(t *testing.T) {
-			assert.JSONEq(t, `[{"description":"Test Provider","name":"provider-one","reason":""},{"description":"Test Provider","name":"provider-two","reason":""}]`, string(bytes),
-				"expected JSON to match the expected format")
-		})
-		assert.Empty(t, notAvailableTools, "expected no not available tools to be returned when no providers are registered")
-	})
-}
-
-func TestGetDefaultPolicies(t *testing.T) {
-	testCase(t, func(c *testContext) {
-		Register(&TestProvider{
-			BasicToolsProvider: BasicToolsProvider{
-				BasicToolsAttributes: BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{
-						FeatureName:        "provider-one",
-						FeatureDescription: "Test Provider",
-					},
-				},
-			},
-			Available: true,
-			Policies: map[string]any{
-				"provider-one-policy": "provider-one-policy-value",
-			},
-		})
-		Register(&TestProvider{
-			BasicToolsProvider: BasicToolsProvider{
-				BasicToolsAttributes: BasicToolsAttributes{
-					BasicFeatureAttributes: api.BasicFeatureAttributes{
-						FeatureName:        "provider-two",
-						FeatureDescription: "Test Provider",
-					},
-				},
-			},
-			Available: true,
-			Policies: map[string]any{
-				"provider-two-policy": "provider-two-policy-value",
-			},
-		})
-		t.Run("GetDefaultPolicies returns expected policies", func(t *testing.T) {
-			policies := GetDefaultPolicies()
-			fmt.Printf("policies: %+v\n", policies)
-			assert.Equal(t, map[string]any{"provider-one-policy": "provider-one-policy-value"}, policies["provider-one"], "expected the provider-one policy to be returned")
-			assert.Equal(t, map[string]any{"provider-two-policy": "provider-two-policy-value"}, policies["provider-two"], "expected the provider-two policy to be returned")
-		})
-	})
+	suite.Run(t, new(DiscoverTestSuite))
 }

--- a/pkg/tools/fs/fs.go
+++ b/pkg/tools/fs/fs.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Provider struct {
-	tools.BasicToolsProvider
+	api.BasicToolsProvider
 }
 
 var _ api.ToolsProvider = &Provider{}
@@ -21,15 +21,15 @@ type FsPolicies struct {
 	policies.ToolPolicies
 }
 
-func (p *Provider) IsAvailable(_ *config.Config, toolPolicies any) bool {
+func (p *Provider) Initialize(_ *config.Config, toolPolicies any) {
 	// TODO: This should probably be generalized to all tools and inference providers
 	if !policies.IsEnabledByPolicies(toolPolicies) {
 		p.IsAvailableReason = "filesystem is not authorized by policies"
-		return false
+		return
 	}
 	// ReadOnly is not considered for fs, as all operations are read-only
+	p.Available = true
 	p.IsAvailableReason = "filesystem is accessible"
-	return true
 }
 
 func (p *Provider) GetTools(_ context.Context, _ *config.Config) ([]*api.Tool, error) {
@@ -94,8 +94,8 @@ func (p *Provider) GetDefaultPolicies() map[string]any {
 }
 
 var instance = &Provider{
-	tools.BasicToolsProvider{
-		BasicToolsAttributes: tools.BasicToolsAttributes{
+	api.BasicToolsProvider{
+		BasicToolsAttributes: api.BasicToolsAttributes{
 			BasicFeatureAttributes: api.BasicFeatureAttributes{
 				FeatureName:        "fs",
 				FeatureDescription: "Provides access to the local filesystem, allowing listing of files and directories.",

--- a/pkg/tools/kubernetes/kubernetes.go
+++ b/pkg/tools/kubernetes/kubernetes.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Provider struct {
-	tools.BasicToolsProvider
+	api.BasicToolsProvider
 	ReadOnly           bool `json:"-"`
 	DisableDestructive bool `json:"-"`
 }
@@ -117,11 +117,11 @@ func homedir() string {
 	return os.Getenv("HOME")
 }
 
-func (p *Provider) IsAvailable(_ *config.Config, toolPolicies any) bool {
+func (p *Provider) Initialize(_ *config.Config, toolPolicies any) {
 	// TODO: This should probably be generalized to all tools and inference providers
 	if !policies.IsEnabledByPolicies(toolPolicies) {
 		p.IsAvailableReason = "kubernetes is not authorized by policies"
-		return false
+		return
 	}
 
 	if policies.IsReadOnlyByPolicies(toolPolicies) {
@@ -136,7 +136,7 @@ func (p *Provider) IsAvailable(_ *config.Config, toolPolicies any) bool {
 	p.McpSettings, err = findBestMcpServerSettings(p.ReadOnly, p.DisableDestructive)
 	if err != nil {
 		p.IsAvailableReason = err.Error()
-		return false
+		return
 	}
 
 	// using the same logic as kubectl to find the config files
@@ -157,7 +157,8 @@ func (p *Provider) IsAvailable(_ *config.Config, toolPolicies any) bool {
 			} else {
 				p.IsAvailableReason = "kubeconfig file found in the locations specified by the KUBECONFIG environment variable"
 			}
-			return true
+			p.Available = true
+			return
 		}
 	}
 	if len(envVarFiles) == 0 {
@@ -165,7 +166,6 @@ func (p *Provider) IsAvailable(_ *config.Config, toolPolicies any) bool {
 	} else {
 		p.IsAvailableReason = "no kubeconfig file found in the locations specified by the KUBECONFIG environment variable"
 	}
-	return false
 }
 
 func (p *Provider) GetTools(ctx context.Context, _ *config.Config) ([]*api.Tool, error) {
@@ -237,8 +237,8 @@ func (p *Provider) GetDefaultPolicies() map[string]any {
 }
 
 var instance = &Provider{
-	BasicToolsProvider: tools.BasicToolsProvider{
-		BasicToolsAttributes: tools.BasicToolsAttributes{
+	BasicToolsProvider: api.BasicToolsProvider{
+		BasicToolsAttributes: api.BasicToolsAttributes{
 			BasicFeatureAttributes: api.BasicFeatureAttributes{
 				FeatureName:        "kubernetes",
 				FeatureDescription: "Provides access to Kubernetes clusters, allowing management and interaction with cluster resources.",

--- a/pkg/tools/postgresql/postgresql_test.go
+++ b/pkg/tools/postgresql/postgresql_test.go
@@ -94,7 +94,8 @@ func TestIsAvailable(t *testing.T) {
 			t.Setenv("PGPORT", tt.pgPort)
 			t.Setenv("PGUSER", tt.pgUser)
 			provider := &Provider{}
-			available := provider.IsAvailable(nil, nil)
+			provider.Initialize(nil, nil)
+			available := provider.IsAvailable()
 			if available != tt.available {
 				t.Errorf("expected postgresql to be %v", tt.available)
 			}


### PR DESCRIPTION
- Removed logic from **`IsAvailable`** The method was performing logic beyond the availability computation, such as model retrieval and so on. Created specific **`Initialize`** method to perform the entire computations. In the future this might allow to lazily call the method after loading the TUI (chat interface) for example.
- Consolidated availability classification and sorting in the features package (removes redundancies from tools and inference) Policies should be consolidated here to, best case scenario would be that features had no notion about policies, etc.
- Refactored some more tests to use testify