### PR TITLE
refactor(policies): consolidate feature classification

### DIFF
--- a/pkg/api/policies.go
+++ b/pkg/api/policies.go
@@ -5,6 +5,8 @@ type InferencePropertyPolicies struct {
 	Public InferenceProviderPolicies `toml:"public,omitempty"`
 }
 
+// InferenceProviderPolicies struct to define policies for inference providers
+//
 // Inference policies can be defined at different levels (highest priority first): by a provider name, by a provider property, or globally
 // Policies are pointers, this means that if a policy is not set at a specific level, the value at a lower level is used
 // If the policy is not set in any of these levels, a default value, defined in the policy package, is used
@@ -21,6 +23,8 @@ type InferencePolicies struct {
 	InferenceProviderPolicies
 }
 
+// ToolsProviderPolicies struct to define policies for tools providers
+//
 // Tools policies can be defined at different levels (highest priority first): by a provider name, or globally
 // Policies are pointers, this means that if a policy is not set at a specific level, the value at a lower level is used
 // If the policy is not set in any of these levels, a default value, defined in the policy package, is used
@@ -45,6 +49,8 @@ type Policies struct {
 	Inferences InferencePolicies `toml:"inferences,omitempty"`
 	Tools      ToolsPolicies     `toml:"tools,omitempty"`
 }
+
+type PolicyVerifier[a FeatureAttributes] func(feature Feature[a], policies *Policies) bool
 
 type PoliciesProvider interface {
 	Read(policiesFile string) (*Policies, error)

--- a/pkg/features/discover.go
+++ b/pkg/features/discover.go
@@ -17,9 +17,13 @@ import (
 type Features struct {
 	Inferences             []api.InferenceProvider `json:"inferences"`             // List of available inference providers
 	InferencesNotAvailable []api.InferenceProvider `json:"inferencesNotAvailable"` // List of not available inference providers
-	Inference              *api.InferenceProvider  `json:"inference"`              // The selected inference provider based on user preferences or auto-detection, or nil if no inference provider is selected
-	Tools                  []api.ToolsProvider     `json:"tools"`                  // List of available tools
-	ToolsNotAvailable      []api.ToolsProvider     `json:"toolsNotAvailable"`      // List of not available tools
+	// TODO: should this be exposed in the outputs?
+	InferencesDisabledByPolicy []api.InferenceProvider `json:"-"`                 // List of inference providers disabled by policies
+	Inference                  *api.InferenceProvider  `json:"inference"`         // The selected inference provider based on user preferences or auto-detection, or nil if no inference provider is selected
+	Tools                      []api.ToolsProvider     `json:"tools"`             // List of available tools
+	ToolsNotAvailable          []api.ToolsProvider     `json:"toolsNotAvailable"` // List of not available tools
+	// TODO: should this be exposed in the outputs?
+	ToolsDisabledByPolicy []api.ToolsProvider `json:"-"` // List of tools providers disabled by policies
 }
 
 // ToJSON converts the features to a generic JSON string representation.
@@ -61,57 +65,47 @@ func toHumanReadable[A api.FeatureAttributes](p api.Feature[A]) string {
 	return ret.String()
 }
 
-func Discover(ctx context.Context) *Features {
-	unregisterDisabledInferences(ctx)
-	unregisterDisabledTools(ctx)
-	cfg := config.GetConfig(ctx)
-	availableInferences, notAvailableInferences := classify(inference.Initialize(ctx)) // TODO: pass preferences for inference
+func Discover(ctx context.Context) (features *Features) {
+	features = &Features{}
 
-	var selectedInference *api.InferenceProvider
-	if cfg.Inference != nil {
-		for _, i := range availableInferences {
+	features.Inferences, features.InferencesDisabledByPolicy = classifyByPolicy(ctx, inference.Initialize(ctx), policies.PoliciesProvider.IsInferenceEnabledByPolicies)
+	features.Inferences, features.InferencesNotAvailable = classifyByAvailability(features.Inferences) // TODO: pass preferences for inference
+
+	if cfg := config.GetConfig(ctx); cfg != nil && cfg.Inference != nil {
+		for _, i := range features.Inferences {
 			if i.Attributes().Name() == *cfg.Inference {
-				selectedInference = &i
+				features.Inference = &i
 				break
 			}
 		}
-	} else if len(availableInferences) > 0 {
+	} else if len(features.Inferences) > 0 {
 		// TODO: Implement user preferences or auto-detection logic to select the best inference
 		// For now, we just select the first available inference
-		selectedInference = &availableInferences[0]
+		features.Inference = &features.Inferences[0]
 	}
 
-	availableTools, notAvailableTools := classify(tools.Initialize(ctx))
-	return &Features{
-		Inferences:             availableInferences,
-		InferencesNotAvailable: notAvailableInferences,
-		Inference:              selectedInference,
-		Tools:                  availableTools,
-		ToolsNotAvailable:      notAvailableTools,
-	}
+	features.Tools, features.ToolsDisabledByPolicy = classifyByPolicy(ctx, tools.Initialize(ctx), policies.PoliciesProvider.IsToolEnabledByPolicies)
+	features.Tools, features.ToolsNotAvailable = classifyByAvailability(features.Tools)
+	return
 }
 
-func unregisterDisabledInferences(ctx context.Context) {
+func classifyByPolicy[A api.FeatureAttributes, F api.Feature[A]](ctx context.Context, providers []F, verifier api.PolicyVerifier[A]) (availableFeatures []F, notAvailableFeatures []F) {
+	availableFeatures = []F{}
+	notAvailableFeatures = []F{}
 	ctxPolicies := policies.GetPolicies(ctx)
-	for name, provider := range inference.GetProviders() {
-		if ctxPolicies != nil && !policies.PoliciesProvider.IsInferenceEnabledByPolicies(provider, ctxPolicies) {
-			inference.Unregister(name)
-			continue
+	for _, provider := range providers {
+		if ctxPolicies == nil || verifier(provider, ctxPolicies) {
+			availableFeatures = append(availableFeatures, provider)
+		} else {
+			notAvailableFeatures = append(notAvailableFeatures, provider)
 		}
 	}
+	slices.SortFunc(availableFeatures, api.FeatureSorter)
+	slices.SortFunc(notAvailableFeatures, api.FeatureSorter)
+	return
 }
 
-func unregisterDisabledTools(ctx context.Context) {
-	ctxPolicies := policies.GetPolicies(ctx)
-	for name, provider := range tools.GetProviders() {
-		if ctxPolicies != nil && !policies.PoliciesProvider.IsToolEnabledByPolicies(provider, ctxPolicies) {
-			tools.Unregister(name)
-			continue
-		}
-	}
-}
-
-func classify[A api.FeatureAttributes, F api.Feature[A]](providers []F) (availableFeatures []F, notAvailableFeatures []F) {
+func classifyByAvailability[A api.FeatureAttributes, F api.Feature[A]](providers []F) (availableFeatures []F, notAvailableFeatures []F) {
 	availableFeatures = []F{}
 	notAvailableFeatures = []F{}
 	for _, provider := range providers {

--- a/pkg/inference/discover.go
+++ b/pkg/inference/discover.go
@@ -22,14 +22,6 @@ func Register(provider api.InferenceProvider) {
 	providers[provider.Attributes().Name()] = provider
 }
 
-func GetProviders() map[string]api.InferenceProvider {
-	return providers
-}
-
-func Unregister(name string) {
-	delete(providers, name)
-}
-
 // Clear the registered tools providers (Exposed for testing purposes)
 func Clear() {
 	providers = map[string]api.InferenceProvider{}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -22,14 +22,6 @@ func Register(provider api.ToolsProvider) {
 	providers[provider.Attributes().Name()] = provider
 }
 
-func GetProviders() map[string]api.ToolsProvider {
-	return providers
-}
-
-func Unregister(name string) {
-	delete(providers, name)
-}
-
 // Clear the registered tools providers (Exposed for testing purposes)
 func Clear() {
 	providers = map[string]api.ToolsProvider{}


### PR DESCRIPTION
To make feature classification more straightforward, extensible, and easier to understand, these changes consolidate feature classification into different common methods.

The features.Discover function is responsible for the orchestration.

For each feature type we have (currently) two classifications: policy disabling and system availability.

Policy disabling is checked first to ensure that disabled features are not processed. System availability is checked for those features that are enabled by policies.

Follows up on #66