### PR TITLE
feat: config updated with policies

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1,0 +1,10 @@
+package api
+
+type Config struct {
+	GoogleApiKey string  // TODO: will likely be removed
+	GeminiModel  string  // TODO: will likely be removed
+	Inference    *string // An inference to use, if not set, the best inference will be used
+	Model        *string // A model to use, if not set, the best model will be used
+
+	ToolsParameters map[string]ToolParameters
+}

--- a/pkg/api/policies.go
+++ b/pkg/api/policies.go
@@ -50,13 +50,13 @@ type Policies struct {
 	Tools      ToolsPolicies     `toml:"tools,omitempty"`
 }
 
-type PolicyVerifier[a FeatureAttributes] func(feature Feature[a], policies *Policies) bool
+type PolicyVerifier[a FeatureAttributes] func(feature Feature[a], policies *Policies) (result bool, enforced bool)
 
 type PoliciesProvider interface {
 	Read(policiesFile string) (*Policies, error)
-	IsInferenceEnabledByPolicies(feature Feature[InferenceAttributes], policies *Policies) bool
-	IsToolEnabledByPolicies(feature Feature[ToolsAttributes], policies *Policies) bool
-	IsToolLocalByPolicies(feature Feature[ToolsAttributes], policies *Policies) bool
-	IsToolNonDestructiveByPolicies(feature Feature[ToolsAttributes], policies *Policies) bool
-	IsToolReadonlyByPolicies(feature Feature[ToolsAttributes], policies *Policies) bool
+	IsInferenceEnabledByPolicies(feature Feature[InferenceAttributes], policies *Policies) (result bool, enforced bool)
+	IsToolEnabledByPolicies(feature Feature[ToolsAttributes], policies *Policies) (result bool, enforced bool)
+	IsToolLocalByPolicies(feature Feature[ToolsAttributes], policies *Policies) (result bool, enforced bool)
+	IsToolNonDestructiveByPolicies(feature Feature[ToolsAttributes], policies *Policies) (result bool, enforced bool)
+	IsToolReadonlyByPolicies(feature Feature[ToolsAttributes], policies *Policies) (result bool, enforced bool)
 }

--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -19,6 +19,12 @@ type ToolsAttributes interface {
 	FeatureAttributes
 }
 
+type ToolParameters struct {
+	Local          bool
+	NonDestructive bool
+	ReadOnly       bool
+}
+
 type BasicToolsProvider struct {
 	ToolsProvider `json:"-"`
 	BasicToolsAttributes

--- a/pkg/cmd/chat.go
+++ b/pkg/cmd/chat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manusa/ai-cli/pkg/config"
 	"github.com/manusa/ai-cli/pkg/features"
 	"github.com/manusa/ai-cli/pkg/policies"
+	"github.com/manusa/ai-cli/pkg/tools"
 	"github.com/manusa/ai-cli/pkg/ui"
 	"github.com/spf13/cobra"
 )
@@ -68,6 +69,7 @@ func NewChatCmd() *cobra.Command {
 // It converts user input into a usable configuration
 func (o *ChatCmdOptions) Complete(cmd *cobra.Command, _ []string) error {
 	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
 
 	if o.inference != "" {
 		cfg.Inference = &o.inference

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/manusa/ai-cli/pkg/api"
 	"github.com/spf13/afero"
 )
 
@@ -35,15 +36,8 @@ func IsDesktop() bool {
 	}
 }
 
-type Config struct {
-	GoogleApiKey string  // TODO: will likely be removed
-	GeminiModel  string  // TODO: will likely be removed
-	Inference    *string // An inference to use, if not set, the best inference will be used
-	Model        *string // A model to use, if not set, the best model will be used
-}
-
-func New() *Config {
-	return &Config{
+func New() *api.Config {
+	return &api.Config{
 		GoogleApiKey: os.Getenv("GEMINI_API_KEY"),
 		GeminiModel:  "gemini-2.0-flash",
 	}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -1,17 +1,21 @@
 package config
 
-import "context"
+import (
+	"context"
+
+	"github.com/manusa/ai-cli/pkg/api"
+)
 
 type configCtxKeyType struct{}
 
 var configCtxKey = configCtxKeyType{}
 
-func WithConfig(ctx context.Context, config *Config) context.Context {
+func WithConfig(ctx context.Context, config *api.Config) context.Context {
 	return context.WithValue(ctx, configCtxKey, config)
 }
 
-func GetConfig(ctx context.Context) *Config {
-	config, ok := ctx.Value(configCtxKey).(*Config)
+func GetConfig(ctx context.Context) *api.Config {
+	config, ok := ctx.Value(configCtxKey).(*api.Config)
 	if !ok {
 		return nil
 	}

--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -35,7 +35,10 @@ func (s *DiscoverTestSuite) TearDownTest() {
 }
 
 func (s *DiscoverTestSuite) TestDiscoverInferenceWithNoProviders() {
-	features := Discover(config.WithConfig(s.T().Context(), config.New()))
+	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
+	ctx := config.WithConfig(s.T().Context(), cfg)
+	features := Discover(ctx)
 	s.Run("With no providers registered returns empty", func() {
 		s.Empty(features.Inferences, "expected no discovered inferences to be returned when no providers are registered")
 		s.Empty(features.InferencesNotAvailable, "expected no discovered inferences to be returned when no providers are registered")
@@ -54,7 +57,10 @@ func (s *DiscoverTestSuite) TestDiscoverInferenceWithOneProviderAvailable() {
 		"provider-unavailable",
 		test.WithInferenceLocal(),
 	))
-	features := Discover(config.WithConfig(s.T().Context(), config.New()))
+	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
+	ctx := config.WithConfig(s.T().Context(), cfg)
+	features := Discover(ctx)
 	s.Run("With one available provider returns features", func() {
 		s.NotNil(features, "expected an inference to be returned")
 	})
@@ -89,10 +95,12 @@ func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProvider() {
 		test.WithInferenceAvailable(),
 	))
 	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
+	ctx := config.WithConfig(s.T().Context(), cfg)
 	cfg.Inference = func(s string) *string {
 		return &s
 	}("provider-2")
-	features := Discover(config.WithConfig(s.T().Context(), cfg))
+	features := Discover(ctx)
 	s.Run("Inference is set to configured provider", func() {
 		s.Equal("provider-2", (*features.Inference).Attributes().Name(),
 			"expected the configured provider to be returned")
@@ -147,6 +155,7 @@ func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProviderUnknown() {
 		test.WithInferenceAvailable(),
 	))
 	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
 	cfg.Inference = func(s string) *string {
 		return &s
 	}("unknown-provider")
@@ -157,7 +166,10 @@ func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProviderUnknown() {
 }
 
 func (s *DiscoverTestSuite) TestDiscoverToolsWithNoProviders() {
-	features := Discover(config.WithConfig(s.T().Context(), config.New()))
+	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
+	ctx := config.WithConfig(s.T().Context(), cfg)
+	features := Discover(ctx)
 	s.Run("With no providers registered returns empty", func() {
 		s.Empty(features.Tools, "expected no discovered tools to be returned when no providers are registered")
 		s.Empty(features.ToolsNotAvailable, "expected no discovered tools to be returned when no providers are registered")
@@ -191,7 +203,9 @@ func (s *DiscoverTestSuite) TestDiscoverToolsWithPolicies() {
 		enabled = false
 	`
 	ctx := policies.WithPolicies(s.T().Context(), test.Must(policies.ReadToml(policiesToml)))
-	ctx = config.WithConfig(ctx, config.New())
+	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
+	ctx = config.WithConfig(ctx, cfg)
 	features := Discover(ctx)
 	s.Run("With two available providers and policy disabled, returns features", func() {
 		s.NotNil(features, "expected an inference to be returned")
@@ -238,7 +252,10 @@ func (s *DiscoverTestSuite) TestDiscoverToJSON() {
 			provider.IsAvailableReason = "tools conditions met"
 		},
 	))
-	features := Discover(config.WithConfig(s.T().Context(), config.New()))
+	cfg := config.New()
+	cfg.ToolsParameters = tools.GetDefaultParameters()
+	ctx := config.WithConfig(s.T().Context(), cfg)
+	features := Discover(ctx)
 	jsonString, err := features.ToJSON()
 	s.Run("Marshalling returns no error", func() {
 		s.Nil(err, "expected no error when marshalling inferences")

--- a/pkg/policies/inference-enabled.go
+++ b/pkg/policies/inference-enabled.go
@@ -2,29 +2,28 @@ package policies
 
 import "github.com/manusa/ai-cli/pkg/api"
 
-const (
-	DefaultInferenceEnabled = true
-)
-
-func (p *Provider) IsInferenceEnabledByPolicies(feature api.Feature[api.InferenceAttributes], policies *api.Policies) bool {
+func (p *Provider) IsInferenceEnabledByPolicies(feature api.Feature[api.InferenceAttributes], policies *api.Policies) (value bool, enforced bool) {
+	if policies == nil {
+		return false, false
+	}
 	providerName := feature.Attributes().Name()
 	if policies.Inferences.Provider[providerName].Enabled != nil {
-		return *policies.Inferences.Provider[providerName].Enabled
+		return *policies.Inferences.Provider[providerName].Enabled, true
 	}
 
 	providerLocal := feature.Attributes().Local()
 	if policies.Inferences.Property.Remote.Enabled != nil {
 		if !*policies.Inferences.Property.Remote.Enabled && !providerLocal {
-			return false
+			return false, true
 		}
 		if *policies.Inferences.Property.Remote.Enabled && !providerLocal {
-			return true
+			return true, true
 		}
 	}
 
 	if policies.Inferences.Enabled != nil {
-		return *policies.Inferences.Enabled
+		return *policies.Inferences.Enabled, true
 	}
 
-	return DefaultInferenceEnabled
+	return false, false
 }

--- a/pkg/policies/inference-enabled_test.go
+++ b/pkg/policies/inference-enabled_test.go
@@ -14,10 +14,12 @@ func TestIsInferenceEnabledByPolicies(t *testing.T) {
 		feature      api.Feature[api.InferenceAttributes]
 		policiesToml string
 		expected     bool
+		enforced     bool
 	}{
 		{
 			name:     "inference enabled by default",
-			expected: true,
+			expected: false,
+			enforced: false,
 			feature: &test.InferenceProvider{
 				BasicInferenceProvider: api.BasicInferenceProvider{
 					BasicInferenceAttributes: api.BasicInferenceAttributes{
@@ -30,6 +32,7 @@ func TestIsInferenceEnabledByPolicies(t *testing.T) {
 		{
 			name:     "provider disabled by name",
 			expected: false,
+			enforced: true,
 			feature: &test.InferenceProvider{
 				BasicInferenceProvider: api.BasicInferenceProvider{
 					BasicInferenceAttributes: api.BasicInferenceAttributes{
@@ -45,6 +48,7 @@ enabled = false
 		{
 			name:     "provider enabled by name",
 			expected: true,
+			enforced: true,
 			feature: &test.InferenceProvider{
 				BasicInferenceProvider: api.BasicInferenceProvider{
 					BasicInferenceAttributes: api.BasicInferenceAttributes{
@@ -63,6 +67,7 @@ enabled = true
 		{
 			name:     "remote provider disabled by remote property",
 			expected: false,
+			enforced: true,
 			feature: &test.InferenceProvider{
 				BasicInferenceProvider: api.BasicInferenceProvider{
 					BasicInferenceAttributes: api.BasicInferenceAttributes{
@@ -79,6 +84,7 @@ enabled = false
 		{
 			name:     "remote provider enabled by remote property",
 			expected: true,
+			enforced: true,
 			feature: &test.InferenceProvider{
 				BasicInferenceProvider: api.BasicInferenceProvider{
 					BasicInferenceAttributes: api.BasicInferenceAttributes{
@@ -99,6 +105,7 @@ enabled = true
 		{
 			name:     "provider disabled globally",
 			expected: false,
+			enforced: true,
 			feature: &test.InferenceProvider{
 				BasicInferenceProvider: api.BasicInferenceProvider{
 					BasicInferenceAttributes: api.BasicInferenceAttributes{
@@ -116,7 +123,9 @@ enabled = false
 			provider := &Provider{}
 			policies, err := ReadToml(tt.policiesToml)
 			assert.NoError(t, err)
-			actual := provider.IsInferenceEnabledByPolicies(tt.feature, policies)
+			actual, enforced := provider.IsInferenceEnabledByPolicies(tt.feature, policies)
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.enforced, enforced)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/policies/tool-enabled.go
+++ b/pkg/policies/tool-enabled.go
@@ -2,21 +2,20 @@ package policies
 
 import "github.com/manusa/ai-cli/pkg/api"
 
-const (
-	DefaultToolEnabled = true
-)
-
-func (p *Provider) IsToolEnabledByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) bool {
+func (p *Provider) IsToolEnabledByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) (value bool, enforced bool) {
+	if policies == nil {
+		return false, false
+	}
 	providerName := feature.Attributes().Name()
 	if policies.Tools.Provider[providerName].Enabled != nil {
-		return *policies.Tools.Provider[providerName].Enabled
+		return *policies.Tools.Provider[providerName].Enabled, true
 	}
 
 	if policies.Tools.Enabled != nil {
-		return *policies.Tools.Enabled
+		return *policies.Tools.Enabled, true
 	}
 
 	// TODO should be disabled if read-only/... is set by policy and provider does not support it
 
-	return DefaultToolEnabled
+	return false, false
 }

--- a/pkg/policies/tool-enabled_test.go
+++ b/pkg/policies/tool-enabled_test.go
@@ -14,10 +14,12 @@ func TestIsToolEnabledByPolicies(t *testing.T) {
 		feature      api.Feature[api.ToolsAttributes]
 		policiesToml string
 		expected     bool
+		enforced     bool
 	}{
 		{
 			name:     "tool enabled by default",
-			expected: true,
+			expected: false,
+			enforced: false,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -30,6 +32,7 @@ func TestIsToolEnabledByPolicies(t *testing.T) {
 		{
 			name:     "provider disabled by name",
 			expected: false,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -45,6 +48,7 @@ enabled = false
 		{
 			name:     "provider enabled by name",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -63,6 +67,7 @@ enabled = true
 		{
 			name:     "provider disabled globally",
 			expected: false,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -80,7 +85,9 @@ enabled = false
 			provider := &Provider{}
 			policies, err := ReadToml(tt.policiesToml)
 			assert.NoError(t, err)
-			actual := provider.IsToolEnabledByPolicies(tt.feature, policies)
+			actual, enforced := provider.IsToolEnabledByPolicies(tt.feature, policies)
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.enforced, enforced)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/policies/tool-local.go
+++ b/pkg/policies/tool-local.go
@@ -2,19 +2,18 @@ package policies
 
 import "github.com/manusa/ai-cli/pkg/api"
 
-const (
-	DefaultToolLocal = false
-)
-
-func (p *Provider) IsToolLocalByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) bool {
+func (p *Provider) IsToolLocalByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) (value bool, enforced bool) {
+	if policies == nil {
+		return false, false
+	}
 	providerName := feature.Attributes().Name()
 	if policies.Tools.Provider[providerName].Local != nil {
-		return *policies.Tools.Provider[providerName].Local
+		return *policies.Tools.Provider[providerName].Local, true
 	}
 
 	if policies.Tools.Local != nil {
-		return *policies.Tools.Local
+		return *policies.Tools.Local, true
 	}
 
-	return DefaultToolLocal
+	return false, false
 }

--- a/pkg/policies/tool-local_test.go
+++ b/pkg/policies/tool-local_test.go
@@ -14,10 +14,12 @@ func TestIsToolLocalByPolicies(t *testing.T) {
 		feature      api.Feature[api.ToolsAttributes]
 		policiesToml string
 		expected     bool
+		enforced     bool
 	}{
 		{
 			name:     "tool not local by default",
 			expected: false,
+			enforced: false,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -30,6 +32,7 @@ func TestIsToolLocalByPolicies(t *testing.T) {
 		{
 			name:     "provider local by name",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -45,6 +48,7 @@ local = true
 		{
 			name:     "provider not local by name",
 			expected: false,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -63,6 +67,7 @@ local = false
 		{
 			name:     "provider local globally",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -80,7 +85,8 @@ local = true
 			provider := &Provider{}
 			policies, err := ReadToml(tt.policiesToml)
 			assert.NoError(t, err)
-			actual := provider.IsToolLocalByPolicies(tt.feature, policies)
+			actual, enforced := provider.IsToolLocalByPolicies(tt.feature, policies)
+			assert.Equal(t, tt.enforced, enforced)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/policies/tool-non-destructive.go
+++ b/pkg/policies/tool-non-destructive.go
@@ -2,19 +2,18 @@ package policies
 
 import "github.com/manusa/ai-cli/pkg/api"
 
-const (
-	DefaultToolNonDestructive = false
-)
-
-func (p *Provider) IsToolNonDestructiveByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) bool {
+func (p *Provider) IsToolNonDestructiveByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) (value bool, enforced bool) {
+	if policies == nil {
+		return false, false
+	}
 	providerName := feature.Attributes().Name()
 	if policies.Tools.Provider[providerName].NonDestructive != nil {
-		return *policies.Tools.Provider[providerName].NonDestructive
+		return *policies.Tools.Provider[providerName].NonDestructive, true
 	}
 
 	if policies.Tools.NonDestructive != nil {
-		return *policies.Tools.NonDestructive
+		return *policies.Tools.NonDestructive, true
 	}
 
-	return DefaultToolNonDestructive
+	return false, false
 }

--- a/pkg/policies/tool-non-destructive_test.go
+++ b/pkg/policies/tool-non-destructive_test.go
@@ -14,10 +14,12 @@ func TestIsToolNonDestructiveByPolicies(t *testing.T) {
 		feature      api.Feature[api.ToolsAttributes]
 		policiesToml string
 		expected     bool
+		enforced     bool
 	}{
 		{
 			name:     "tool not non destructive by default",
 			expected: false,
+			enforced: false,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -30,6 +32,7 @@ func TestIsToolNonDestructiveByPolicies(t *testing.T) {
 		{
 			name:     "provider non destructive by name",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -45,6 +48,7 @@ non-destructive = true
 		{
 			name:     "provider not non destructive by name",
 			expected: false,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -63,6 +67,7 @@ non-destructive = false
 		{
 			name:     "provider non destructive globally",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -80,7 +85,8 @@ non-destructive = true
 			provider := &Provider{}
 			policies, err := ReadToml(tt.policiesToml)
 			assert.NoError(t, err)
-			actual := provider.IsToolNonDestructiveByPolicies(tt.feature, policies)
+			actual, enforced := provider.IsToolNonDestructiveByPolicies(tt.feature, policies)
+			assert.Equal(t, tt.enforced, enforced)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/policies/tool-readonly.go
+++ b/pkg/policies/tool-readonly.go
@@ -2,19 +2,18 @@ package policies
 
 import "github.com/manusa/ai-cli/pkg/api"
 
-const (
-	DefaultToolReadonly = false
-)
-
-func (p *Provider) IsToolReadonlyByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) bool {
+func (p *Provider) IsToolReadonlyByPolicies(feature api.Feature[api.ToolsAttributes], policies *api.Policies) (value bool, enforced bool) {
+	if policies == nil {
+		return false, false
+	}
 	providerName := feature.Attributes().Name()
 	if policies.Tools.Provider[providerName].ReadOnly != nil {
-		return *policies.Tools.Provider[providerName].ReadOnly
+		return *policies.Tools.Provider[providerName].ReadOnly, true
 	}
 
 	if policies.Tools.ReadOnly != nil {
-		return *policies.Tools.ReadOnly
+		return *policies.Tools.ReadOnly, true
 	}
 
-	return DefaultToolReadonly
+	return false, false
 }

--- a/pkg/policies/tool-readonly_test.go
+++ b/pkg/policies/tool-readonly_test.go
@@ -14,10 +14,12 @@ func TestIsToolReadonlyByPolicies(t *testing.T) {
 		feature      api.Feature[api.ToolsAttributes]
 		policiesToml string
 		expected     bool
+		enforced     bool
 	}{
 		{
 			name:     "tool not read-only by default",
 			expected: false,
+			enforced: false,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -30,6 +32,7 @@ func TestIsToolReadonlyByPolicies(t *testing.T) {
 		{
 			name:     "provider read-only by name",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -45,6 +48,7 @@ read-only = true
 		{
 			name:     "provider not read-only by name",
 			expected: false,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -63,6 +67,7 @@ read-only = false
 		{
 			name:     "provider read only globally",
 			expected: true,
+			enforced: true,
 			feature: &test.ToolsProvider{
 				BasicToolsProvider: api.BasicToolsProvider{
 					BasicToolsAttributes: api.BasicToolsAttributes{
@@ -80,7 +85,8 @@ read-only = true
 			provider := &Provider{}
 			policies, err := ReadToml(tt.policiesToml)
 			assert.NoError(t, err)
-			actual := provider.IsToolReadonlyByPolicies(tt.feature, policies)
+			actual, enforced := provider.IsToolReadonlyByPolicies(tt.feature, policies)
+			assert.Equal(t, tt.enforced, enforced)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/tools/discover.go
+++ b/pkg/tools/discover.go
@@ -34,3 +34,21 @@ func Initialize(ctx context.Context) []api.ToolsProvider {
 	}
 	return slices.SortedFunc(maps.Values(providers), api.FeatureSorter)
 }
+
+func GetProviders() map[string]api.ToolsProvider {
+	return providers
+}
+
+// GetDefaultParameters returns the default tool parameters for the registered providers
+// TODO: all parameters are set to false by default, do we want to change this?
+func GetDefaultParameters() map[string]api.ToolParameters {
+	cfg := map[string]api.ToolParameters{}
+	for _, provider := range providers {
+		cfg[provider.Attributes().Name()] = api.ToolParameters{
+			Local:          false,
+			NonDestructive: false,
+			ReadOnly:       false,
+		}
+	}
+	return cfg
+}

--- a/pkg/tools/github/github.go
+++ b/pkg/tools/github/github.go
@@ -44,7 +44,12 @@ var (
 	}
 )
 
-func (p *Provider) Initialize(_ context.Context) {
+func (p *Provider) Initialize(ctx context.Context) {
+	cfg := config.GetConfig(ctx)
+	if cfg != nil && cfg.ToolsParameters[p.Attributes().Name()].ReadOnly {
+		p.ReadOnly = true
+	}
+
 	hasAccessToken := os.Getenv(accessTokenEnvVar) != ""
 	if !hasAccessToken {
 		p.IsAvailableReason = fmt.Sprintf("%s is not set", accessTokenEnvVar)

--- a/pkg/tools/kubernetes/kubernetes.go
+++ b/pkg/tools/kubernetes/kubernetes.go
@@ -109,7 +109,14 @@ func homedir() string {
 	return os.Getenv("HOME")
 }
 
-func (p *Provider) Initialize(_ context.Context) {
+func (p *Provider) Initialize(ctx context.Context) {
+	cfg := config.GetConfig(ctx)
+	if cfg != nil && cfg.ToolsParameters[p.Attributes().Name()].ReadOnly {
+		p.ReadOnly = true
+	}
+	if cfg != nil && cfg.ToolsParameters[p.Attributes().Name()].NonDestructive {
+		p.DisableDestructive = true
+	}
 	var err error
 	p.McpSettings, err = findBestMcpServerSettings(p.ReadOnly, p.DisableDestructive)
 	if err != nil {

--- a/pkg/tools/postgresql/postgresql.go
+++ b/pkg/tools/postgresql/postgresql.go
@@ -51,7 +51,12 @@ var (
 	}
 )
 
-func (p *Provider) Initialize(_ context.Context) {
+func (p *Provider) Initialize(ctx context.Context) {
+	cfg := config.GetConfig(ctx)
+	if cfg != nil && cfg.ToolsParameters[p.Attributes().Name()].ReadOnly {
+		p.ReadOnly = true
+	}
+
 	var err error
 	p.McpSettings, err = p.findBestMcpServerSettings(p.ReadOnly)
 	if err != nil {


### PR DESCRIPTION
Adds Tools parameters to the Config, and updates them to enforce policies, if any

(I will add more unit tests if we agree on the code)

The caller needs to run:
```
cfg := config.New()
cfg.ToolsParameters = tools.GetDefaultParameters()
```

I would prefer to populate the ToolsParameters as part of the `config.New()`, but this leads to a circular import between `config` and `tools` which we would need to resolve