### PR TITLE
feat(config): added InferenceConfig to align with Tools

### DIFF
--- a/pkg/api/inference.go
+++ b/pkg/api/inference.go
@@ -22,12 +22,18 @@ type InferenceAttributes interface {
 	Public() bool
 }
 
+type InferenceParameters struct {
+	Enabled *bool   `json:"-" toml:"enabled"`
+	Model   *string `json:"-" toml:"enabled"` // A model to use, if not set, the best model will be used
+}
+
 type BasicInferenceProvider struct {
 	InferenceProvider `json:"-"`
 	BasicInferenceAttributes
 	Available         bool     `json:"-"`
 	IsAvailableReason string   `json:"reason"`
 	ProviderModels    []string `json:"models"`
+	InferenceParameters
 }
 
 func (p *BasicInferenceProvider) Attributes() InferenceAttributes {

--- a/pkg/cmd/chat.go
+++ b/pkg/cmd/chat.go
@@ -70,10 +70,10 @@ func (o *ChatCmdOptions) Complete(cmd *cobra.Command, _ []string) error {
 	cfg := config.New()
 
 	if o.inference != "" {
-		cfg.Inference = &o.inference
+		cfg.InferenceConfig.Inference = &o.inference
 	}
 	if o.model != "" {
-		cfg.Model = &o.model
+		cfg.InferenceConfig.Model = &o.model
 	}
 
 	var userPolicies *api.Policies

--- a/pkg/cmd/discover_test.go
+++ b/pkg/cmd/discover_test.go
@@ -56,10 +56,10 @@ func (s *DiscoverTestSuite) TestOutputText() {
 			"    Reason: GEMINI_API_KEY is not set\n" +
 			"  - lmstudio\n" +
 			"    Description: LM Studio local inference provider\n" +
-			"    Reason: http://localhost:1234 is not accessible\n" +
+			"    Reason: LM Studio is not accessible at http://localhost:1234\n" +
 			"  - ollama\n" +
 			"    Description: Ollama local inference provider\n" +
-			"    Reason: http://localhost:1337 is not accessible\n" +
+			"    Reason: ollama is not accessible at http://localhost:1337\n" +
 			"  - ramalama\n" +
 			"    Description: Ramalama local inference provider\n" +
 			"    Reason: ramalama is not installed\n" +
@@ -96,8 +96,8 @@ func (s *DiscoverTestSuite) TestOutputJson() {
 			`"inferences":[],` +
 			`"inferencesNotAvailable":[` +
 			`{"description":"Google Gemini inference provider","name":"gemini","local":false,"public":true,"reason":"GEMINI_API_KEY is not set","models":null},` +
-			`{"description":"LM Studio local inference provider","name":"lmstudio","local":true,"public":false,"reason":"http://localhost:1234 is not accessible","models":null},` +
-			`{"description":"Ollama local inference provider","name":"ollama","local":true,"public":false,"reason":"http://localhost:1337 is not accessible","models":null},` +
+			`{"description":"LM Studio local inference provider","name":"lmstudio","local":true,"public":false,"reason":"LM Studio is not accessible at http://localhost:1234","models":null},` +
+			`{"description":"Ollama local inference provider","name":"ollama","local":true,"public":false,"reason":"ollama is not accessible at http://localhost:1337","models":null},` +
 			`{"description":"Ramalama local inference provider","name":"ramalama","local":true,"public":false,"reason":"ramalama is not installed","models":null}],` +
 			`"inference":null,` +
 			`"tools":[{"description":"Provides access to the local filesystem, allowing listing of files and directories.","name":"fs","reason":"filesystem is accessible"}],` +

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -17,5 +17,7 @@ func GetConfig(ctx context.Context) *Config {
 	if !ok {
 		return nil
 	}
-	return config
+	// Return a copy to avoid side-effects and modifications of the original config
+	configCopy := *config
+	return &configCopy
 }

--- a/pkg/features/discover.go
+++ b/pkg/features/discover.go
@@ -76,9 +76,9 @@ func Discover(ctx context.Context) (features *Features) {
 	inferencesEnabled, features.InferencesDisabledByPolicy = filterDisabled(inference.Initialize(ctx), cfg.IsInferenceProviderEnabled)
 	features.Inferences, features.InferencesNotAvailable = classifyByAvailability(inferencesEnabled) // TODO: pass preferences for inference
 
-	if cfg.Inference != nil {
+	if cfg.Inference() != nil {
 		for _, i := range features.Inferences {
-			if i.Attributes().Name() == *cfg.Inference {
+			if i.Attributes().Name() == *cfg.Inference() {
 				features.Inference = &i
 				break
 			}

--- a/pkg/features/discover_test.go
+++ b/pkg/features/discover_test.go
@@ -89,7 +89,7 @@ func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProvider() {
 		test.WithInferenceAvailable(),
 	))
 	cfg := config.New()
-	cfg.Inference = func(s string) *string {
+	cfg.InferenceConfig.Inference = func(s string) *string {
 		return &s
 	}("provider-2")
 	features := Discover(config.WithConfig(s.T().Context(), cfg))
@@ -147,7 +147,7 @@ func (s *DiscoverTestSuite) TestDiscoverInferenceConfiguredProviderUnknown() {
 		test.WithInferenceAvailable(),
 	))
 	cfg := config.New()
-	cfg.Inference = func(s string) *string {
+	cfg.InferenceConfig.Inference = func(s string) *string {
 		return &s
 	}("unknown-provider")
 	features := Discover(config.WithConfig(s.T().Context(), cfg))

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -20,6 +20,11 @@ type Provider struct {
 var _ api.InferenceProvider = &Provider{}
 
 func (p *Provider) Initialize(ctx context.Context) {
+	// TODO: probably move to features.Discover orchestration
+	if cfg := config.GetConfig(ctx); cfg != nil {
+		p.InferenceParameters = cfg.InferenceParameters(p.Attributes().Name())
+	}
+
 	cfg := config.GetConfig(ctx)
 	p.Available = cfg.GoogleApiKey() != ""
 	if p.Available {


### PR DESCRIPTION
Added inference provider config fields to Config to align with what we have for Tools.

The policy intersection is still hard to resolve.
Policies deal with attributes using inversion of control (local/remote), but is also used to set or enforce configuration values (read-only, etc.).

The Config.Enforce method should be the place to deal with this, however it's not possible to do it because at that level it has no knowledge of the attributes of the different features (and this is difficult or impossible to change).

The alternative is to deal with Enabled/Disabled only at policy level and don't allow to enable or disable globally by config.
A first step towards resolving this issue would be to define what can or can't be configured. By having a clear Config struct and behaviors we can then decide on the right approach.