### PR TITLE
chore: use latest mcp-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/cloudwego/eino-ext/components/tool/mcp v0.0.4
 	github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76
 	github.com/google/uuid v1.6.0
-	github.com/mark3labs/mcp-go v0.36.0
+	github.com/mark3labs/mcp-go v0.39.1
 	github.com/modelcontextprotocol/go-sdk v0.4.0
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/afero v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.36.0 h1:rIZaijrRYPeSbJG8/qNDe0hWlGrCJ7FWHNMz2SQpTis=
-github.com/mark3labs/mcp-go v0.36.0/go.mod h1:T7tUa2jO6MavG+3P25Oy/jR7iCeJPHImCZHRymCn39g=
+github.com/mark3labs/mcp-go v0.39.1 h1:2oPxk7aDbQhouakkYyKl2T4hKFU1c6FDaubWyGyVE1k=
+github.com/mark3labs/mcp-go v0.39.1/go.mod h1:T7tUa2jO6MavG+3P25Oy/jR7iCeJPHImCZHRymCn39g=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/pkg/ai/tools.go
+++ b/pkg/ai/tools.go
@@ -118,9 +118,9 @@ func mcpClientTools(ctx context.Context, mcpClients []*client.Client) (tools []t
 				// https://github.com/cloudwego/eino-ext/issues/436
 				if result.IsError {
 					if result.Meta == nil {
-						result.Meta = make(map[string]interface{})
+						result.Meta = &m3lmcp.Meta{AdditionalFields: make(map[string]interface{})}
 					}
-					result.Meta["error"] = true
+					result.Meta.AdditionalFields["error"] = true
 					result.IsError = false
 				}
 				return result, nil


### PR DESCRIPTION
Use latest version 0.39.1 of `mark3labs/mcp-go`.

This will be needed to be able to use `https://github.com/feloy/browsers-mcp-server` as a library (which includes latest version of `mark3labs/mcp-go`).

