### PR TITLE
fix(ollama): missing compatible model reported + provider not available

### DIFF
--- a/pkg/inference/ollama/ollama_test.go
+++ b/pkg/inference/ollama/ollama_test.go
@@ -31,106 +31,154 @@ func (s *OllamaTestSuite) TearDownTest() {
 }
 
 func (s *OllamaTestSuite) TestInitializeWithNoServer() {
-	instance.Initialize(s.T().Context())
-	s.Run("when no server is running, is not available", func() {
-		s.False(instance.IsAvailable())
-	})
-	s.Run("when no server is running, shows reason", func() {
-		s.Contains(instance.Reason(), "ollama is not accessible at http://localhost:11434")
-	})
-	s.Run("when no server is running, has no models", func() {
-		s.Nil(instance.Models())
-	})
-	s.Run("when no server is running, marshaled JSON shows availability fields", func() {
-		data, err := json.Marshal(instance)
-		s.Run("does not return an error", func() {
-			s.Nil(err)
+	s.Run("no server running", func() {
+		instance.Initialize(s.T().Context())
+		s.Run("is not available", func() {
+			s.False(instance.IsAvailable())
 		})
-		s.Run("returns expected JSON", func() {
-			s.JSONEq(`{`+
-				`"description":"Ollama local inference provider",`+
-				`"local":true,`+
-				`"models":null,`+
-				`"name":"ollama",`+
-				`"public":false,`+
-				`"reason":"ollama is not accessible at http://localhost:11434"`+
-				`}`, string(data))
+		s.Run("shows reason", func() {
+			s.Contains(instance.Reason(), "ollama is not accessible at http://localhost:11434")
+		})
+		s.Run("has no models", func() {
+			s.Nil(instance.Models())
+		})
+		s.Run("marshaled JSON shows availability fields", func() {
+			data, err := json.Marshal(instance)
+			s.Run("does not return an error", func() {
+				s.Nil(err)
+			})
+			s.Run("returns expected JSON", func() {
+				s.JSONEq(`{`+
+					`"description":"Ollama local inference provider",`+
+					`"local":true,`+
+					`"models":null,`+
+					`"name":"ollama",`+
+					`"public":false,`+
+					`"reason":"ollama is not accessible at http://localhost:11434"`+
+					`}`, string(data))
+			})
 		})
 	})
 }
 
 func (s *OllamaTestSuite) TestInitializeWithNoCompatibleServer() {
-	_ = os.Setenv("OLLAMA_HOST", s.MockServer.URL())
-	instance.Initialize(s.T().Context())
-	s.Run("when no server is running, is not available", func() {
-		s.False(instance.IsAvailable())
-	})
-	s.Run("when no server is running, shows reason", func() {
-		s.Regexp("The server at http:\\/\\/.+ defined by the OLLAMA_HOST environment variable is accessible but is not Ollama", instance.Reason())
-	})
-	s.Run("when no server is running, has no models", func() {
-		s.Nil(instance.Models())
-	})
-	s.Run("when no server is running, marshaled JSON shows availability fields", func() {
-		data, err := json.Marshal(instance)
-		s.Run("does not return an error", func() {
-			s.Nil(err)
+	s.Run("incompatible server running", func() {
+		_ = os.Setenv("OLLAMA_HOST", s.MockServer.URL())
+		instance.Initialize(s.T().Context())
+		s.Run("is not available", func() {
+			s.False(instance.IsAvailable())
 		})
-		s.Run("returns expected JSON", func() {
-			s.JSONEq(`{`+
-				`"description":"Ollama local inference provider",`+
-				`"local":true,`+
-				`"models":null,`+
-				`"name":"ollama",`+
-				`"public":false,`+
-				fmt.Sprintf(`"reason":"The server at %s defined by the OLLAMA_HOST environment variable is accessible but is not Ollama"`, s.MockServer.URL())+
-				`}`, string(data))
+		s.Run("shows reason", func() {
+			s.Regexp("The server at http:\\/\\/.+ defined by the OLLAMA_HOST environment variable is accessible but is not Ollama", instance.Reason())
+		})
+		s.Run("has no models", func() {
+			s.Nil(instance.Models())
+		})
+		s.Run("marshaled JSON shows availability fields", func() {
+			data, err := json.Marshal(instance)
+			s.Run("does not return an error", func() {
+				s.Nil(err)
+			})
+			s.Run("returns expected JSON", func() {
+				s.JSONEq(`{`+
+					`"description":"Ollama local inference provider",`+
+					`"local":true,`+
+					`"models":null,`+
+					`"name":"ollama",`+
+					`"public":false,`+
+					fmt.Sprintf(`"reason":"The server at %s defined by the OLLAMA_HOST environment variable is accessible but is not Ollama"`, s.MockServer.URL())+
+					`}`, string(data))
+			})
+		})
+	})
+}
+
+func (s *OllamaTestSuite) TestInitializeWithCompatibleServerMissingModel() {
+	s.Run("compatible server running with unmatched models", func() {
+		s.MockServer.Handle(func(w http.ResponseWriter, req *http.Request) (handled bool) {
+			if req.Method == http.MethodGet && req.URL.Path == "/v1/models" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":[{"id":"model-1"},{"id":"model-2"}]}`))
+				handled = true
+			}
+			return
+		})
+		_ = os.Setenv("OLLAMA_HOST", s.MockServer.URL())
+		instance.Initialize(s.T().Context())
+		s.Run("is not available", func() {
+			s.False(instance.IsAvailable())
+		})
+		s.Run("shows reason", func() {
+			s.Equal(fmt.Sprintf("ollama is accessible at %s defined by the OLLAMA_HOST environment variable but no preferred models (llama3.2:3b, granite3.3:latest, mistral:7b) are served", s.MockServer.URL()), instance.Reason())
+		})
+		s.Run("has models", func() {
+			s.Len(instance.Models(), 2)
+			s.Contains(instance.Models(), "model-1")
+			s.Contains(instance.Models(), "model-2")
+		})
+		s.Run("marshaled JSON shows availability fields", func() {
+			data, err := json.Marshal(instance)
+			s.Run("does not return an error", func() {
+				s.Nil(err)
+			})
+			s.Run("returns expected JSON", func() {
+				s.JSONEq(`{`+
+					`"description":"Ollama local inference provider",`+
+					`"local":true,`+
+					`"models":["model-1", "model-2"],`+
+					`"name":"ollama",`+
+					`"public":false,`+
+					fmt.Sprintf(`"reason":"ollama is accessible at %s defined by the OLLAMA_HOST environment variable but no preferred models (llama3.2:3b, granite3.3:latest, mistral:7b) are served"`, s.MockServer.URL())+
+					`}`, string(data))
+			})
 		})
 	})
 }
 
 func (s *OllamaTestSuite) TestInitializeWithCompatibleServer() {
-	s.MockServer.Handle(func(w http.ResponseWriter, req *http.Request) (handled bool) {
-		if req.Method == http.MethodGet && req.URL.Path == "/v1/models" {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data":[{"id":"model-1"},{"id":"model-2"},{"id":"llama3.2:3b"}]}`))
-			handled = true
-		}
-		return
-	})
-	_ = os.Setenv("OLLAMA_HOST", s.MockServer.URL())
-	instance.Initialize(s.T().Context())
-	s.Run("when a compatible server is running, is available", func() {
-		s.True(instance.IsAvailable())
-	})
-	s.Run("when a compatible server is running, shows reason", func() {
-		s.Regexp(fmt.Sprintf("ollama is accessible at %s defined by the OLLAMA_HOST environment variable", s.MockServer.URL()), instance.Reason())
-	})
-	s.Run("when a compatible server is running, has models", func() {
-		s.Len(instance.Models(), 3)
-		s.Contains(instance.Models(), "model-1")
-		s.Contains(instance.Models(), "model-2")
-		s.Contains(instance.Models(), "llama3.2:3b")
-	})
-	s.Run("when a compatible server is running, sets first compatible model as default", func() {
-		s.NotNil(instance.Model)
-		s.Equal("llama3.2:3b", *instance.Model)
-
-	})
-	s.Run("when a compatible server is running, marshaled JSON shows availability fields", func() {
-		data, err := json.Marshal(instance)
-		s.Run("does not return an error", func() {
-			s.Nil(err)
+	s.Run("compatible server running", func() {
+		s.MockServer.Handle(func(w http.ResponseWriter, req *http.Request) (handled bool) {
+			if req.Method == http.MethodGet && req.URL.Path == "/v1/models" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":[{"id":"model-1"},{"id":"model-2"},{"id":"llama3.2:3b"}]}`))
+				handled = true
+			}
+			return
 		})
-		s.Run("returns expected JSON", func() {
-			s.JSONEq(`{`+
-				`"description":"Ollama local inference provider",`+
-				`"local":true,`+
-				`"models":["model-1", "model-2", "llama3.2:3b"],`+
-				`"name":"ollama",`+
-				`"public":false,`+
-				fmt.Sprintf(`"reason":"ollama is accessible at %s defined by the OLLAMA_HOST environment variable"`, s.MockServer.URL())+
-				`}`, string(data))
+		_ = os.Setenv("OLLAMA_HOST", s.MockServer.URL())
+		instance.Initialize(s.T().Context())
+		s.Run("is available", func() {
+			s.True(instance.IsAvailable())
+		})
+		s.Run("shows reason", func() {
+			s.Regexp(fmt.Sprintf("ollama is accessible at %s defined by the OLLAMA_HOST environment variable", s.MockServer.URL()), instance.Reason())
+		})
+		s.Run("has models", func() {
+			s.Len(instance.Models(), 3)
+			s.Contains(instance.Models(), "model-1")
+			s.Contains(instance.Models(), "model-2")
+			s.Contains(instance.Models(), "llama3.2:3b")
+		})
+		s.Run("sets first compatible model as default", func() {
+			s.NotNil(instance.Model)
+			s.Equal("llama3.2:3b", *instance.Model)
+
+		})
+		s.Run("marshaled JSON shows availability fields", func() {
+			data, err := json.Marshal(instance)
+			s.Run("does not return an error", func() {
+				s.Nil(err)
+			})
+			s.Run("returns expected JSON", func() {
+				s.JSONEq(`{`+
+					`"description":"Ollama local inference provider",`+
+					`"local":true,`+
+					`"models":["model-1", "model-2", "llama3.2:3b"],`+
+					`"name":"ollama",`+
+					`"public":false,`+
+					fmt.Sprintf(`"reason":"ollama is accessible at %s defined by the OLLAMA_HOST environment variable"`, s.MockServer.URL())+
+					`}`, string(data))
+			})
 		})
 	})
 }


### PR DESCRIPTION
When Ollama is running but no compatible-model is found and user doesn't provide a configured model, inference provider is marked as unavailable.

Fixes #74 