### PR TITLE
feat: dynamic toolsets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,11 @@ require (
 	github.com/cloudwego/eino-ext/components/model/gemini v0.1.6
 	github.com/cloudwego/eino-ext/components/model/ollama v0.1.2
 	github.com/cloudwego/eino-ext/components/model/openai v0.0.0-20250828061307-a19adf5c9b50
-	github.com/cloudwego/eino-ext/components/tool/mcp v0.0.4
+	github.com/eino-contrib/jsonschema v1.0.0
 	github.com/feloy/browsers-mcp-server v0.0.4
-	github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76
+	github.com/google/jsonschema-go v0.3.0
 	github.com/google/uuid v1.6.0
-	github.com/mark3labs/mcp-go v0.39.1
-	github.com/modelcontextprotocol/go-sdk v0.4.0
+	github.com/modelcontextprotocol/go-sdk v0.8.0
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/afero v1.14.0
 	github.com/spf13/cobra v1.10.1
@@ -60,7 +59,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/eino-contrib/jsonschema v1.0.0 // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/getkin/kin-openapi v0.118.0 // indirect
@@ -77,7 +75,6 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -104,7 +101,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f // indirect
-	github.com/spf13/cast v1.7.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/cloudwego/eino-ext/components/model/ollama v0.1.2 h1:WxJ+7oXnr3AhM6u4
 github.com/cloudwego/eino-ext/components/model/ollama v0.1.2/go.mod h1:OgGMCiR/G/RnOWaJvdK8pVSxAzoz2SlCqim43oFTuwo=
 github.com/cloudwego/eino-ext/components/model/openai v0.0.0-20250828061307-a19adf5c9b50 h1:qLGSpG29U6oUavKbOVVLfQAR04dSx5aRav370eIWxug=
 github.com/cloudwego/eino-ext/components/model/openai v0.0.0-20250828061307-a19adf5c9b50/go.mod h1:QQhCuQxuBAVWvu/YAZBhs/RsR76mUigw59Tl0kh04C8=
-github.com/cloudwego/eino-ext/components/tool/mcp v0.0.4 h1:4z/ZSIh9SWvleqx66a6azW47/WIyKcYmaO8U0hcvV7s=
-github.com/cloudwego/eino-ext/components/tool/mcp v0.0.4/go.mod h1:riLM7tACo7h89aEXX3ID91UXD7NCakgvXTW5D0F2Nuo=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250826113018-8c6f6358d4bb h1:RMslzyijc3bi9EkqCulpS0hZupTl1y/wayR3+fVRN/c=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250826113018-8c6f6358d4bb/go.mod h1:fHn/6OqPPY1iLLx9wzz+MEVT5Dl9gwuZte1oLEnCoYw=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
@@ -110,8 +108,6 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/feloy/browsers-mcp-server v0.0.4 h1:rO9FwsT36nJYCJ/XrcNTMjpplBQkdc05ovYggKZLEHo=
 github.com/feloy/browsers-mcp-server v0.0.4/go.mod h1:15o+JLgPBK/yQq/hY9EpCbZM3SOZaZZd62+qWaShqPY=
-github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
-github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getkin/kin-openapi v0.118.0 h1:z43njxPmJ7TaPpMSCQb7PN0dEYno4tyBPQcrFdHoLuM=
 github.com/getkin/kin-openapi v0.118.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
@@ -138,8 +134,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 h1:mBlBwtDebdDYr+zdop8N62a44g+Nbv7o2KjWyS1deR4=
-github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/s2a-go v0.1.8 h1:zZDs9gcbt9ZPLV0ndSyQk6Kacx2g/X+SKYovpnz3SMM=
@@ -165,8 +161,6 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
 github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -195,8 +189,6 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.39.1 h1:2oPxk7aDbQhouakkYyKl2T4hKFU1c6FDaubWyGyVE1k=
-github.com/mark3labs/mcp-go v0.39.1/go.mod h1:T7tUa2jO6MavG+3P25Oy/jR7iCeJPHImCZHRymCn39g=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -209,8 +201,8 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1f
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
-github.com/modelcontextprotocol/go-sdk v0.4.0 h1:RJ6kFlneHqzTKPzlQqiunrz9nbudSZcYLmLHLsokfoU=
-github.com/modelcontextprotocol/go-sdk v0.4.0/go.mod h1:whv0wHnsTphwq7CTiKYHkLtwLC06WMoY2KpO+RB9yXQ=
+github.com/modelcontextprotocol/go-sdk v0.8.0 h1:jdsBtGzBLY287WKSIjYovOXAqtJkP+HtFQFKrZd4a6c=
+github.com/modelcontextprotocol/go-sdk v0.8.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -265,8 +257,6 @@ github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sS
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
 github.com/spf13/afero v1.14.0/go.mod h1:acJQ8t0ohCGuMN3O+Pv0V0hgMxNYDlvdk+VTfyZmbYo=
-github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
-github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/pkg/ai/ai_mcp_test.go
+++ b/pkg/ai/ai_mcp_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/manusa/ai-cli/internal/test"
 	"github.com/manusa/ai-cli/pkg/api"
 	"github.com/manusa/ai-cli/pkg/config"
-	"github.com/mark3labs/mcp-go/client"
-	m3lmcp "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,7 +23,7 @@ func (s *AiMcpSuite) SetupTest() {
 	s.Llm = &test.ChatModel{}
 	s.Ai = New(
 		test.NewInferenceProvider("inference-provider", test.WithInferenceAvailable(), test.WithInferenceLlm(s.Llm)),
-		[]api.ToolsProvider{test.NewToolsProvider("test-tools-provider", test.WithToolsAvailable(), test.WithToolsMcpSettings(test.McpServer()))},
+		[]api.ToolsProvider{test.NewToolsProvider("test-toolManager-provider", test.WithToolsAvailable(), test.WithToolsMcpSettings(test.McpServer()))},
 	)
 	if err := s.Ai.Run(config.WithConfig(s.T().Context(), config.New())); err != nil {
 		s.T().Fatalf("failed to run AI: %v", err)
@@ -38,37 +36,37 @@ func (s *AiMcpSuite) TearDownTest() {
 
 func (s *AiMcpSuite) TestRunStartsMcpServers() {
 	s.Require().NotEmpty(s.Ai.mcpClients, "Expected MCP clients to be initialized")
-	s.Run("Adds MCP clients for each MCP-enabled tools provider", func() {
+	s.Run("Adds MCP clients for each MCP-enabled toolManager provider", func() {
 		s.Require().Len(s.Ai.mcpClients, 1, "Expected MCP clients to be initialized")
 	})
 	s.Run("MCP clients are initialized", func() {
-		s.False(slices.ContainsFunc(s.Ai.mcpClients, func(c *client.Client) bool { return !c.IsInitialized() }), "Expected all MCP clients to be initialized")
+		s.False(slices.ContainsFunc(s.Ai.mcpClients, func(c *ToolsProviderMcpClient) bool { return c.InitializeResult() == nil }), "Expected all MCP clients to be initialized")
 	})
 }
 
 func (s *AiMcpSuite) TestCloseShutsDownMcpServers() {
 	s.Require().NotEmpty(s.Ai.mcpClients, "Expected MCP clients to be initialized")
-	s.Ai.mcpClients[0].OnNotification(func(notification m3lmcp.JSONRPCNotification) {
-		println(notification.Method)
-	})
 	s.Ai.Close()
 	s.Run("MCP clients are shut down", func() {
-		err := s.Ai.mcpClients[0].Ping(s.T().Context())
+		err := s.Ai.mcpClients[0].Ping(s.T().Context(), nil)
 		s.Error(err, "Expected error when pinging closed MCP client")
 		s.Contains(err.Error(), "closed", "Expected connection is closed error")
 	})
 }
 
-func (s *AiMcpSuite) TestSetupAgentAddsMcpTools() {
+func (s *AiMcpSuite) TestNewReActAgentAddsOnlyEnableTool() {
 	var receivedTools []*schema.ToolInfo
 	s.Llm.WithToolsFunc = func(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
 		receivedTools = tools
 		return s.Llm, nil
 	}
-	s.Ai.Input() <- api.NewUserMessage("Hello AItana! I'm sending some MCP tools.")
-	s.Require().Eventually(func() bool { return len(receivedTools) > 0 }, 10*time.Second, 100, "Expected LLM to be called with tools")
-	s.Run("Tools includes MCP Server tools", func() {
-		s.True(slices.ContainsFunc(receivedTools, func(t *schema.ToolInfo) bool { return t.Name == "test-func" }), "Expected to find MCP 'test-func' tool in received tools")
+	s.Ai.Input() <- api.NewUserMessage("Hello AItana! I'm sending some MCP toolManager.")
+	s.Require().Eventually(func() bool { return len(receivedTools) > 0 }, 10*time.Second, 100, "Expected LLM to be called with toolManager")
+	s.Run("Tools includes a single tool", func() {
+		s.Len(receivedTools, 1, "Expected only one tool to be passed to LLM")
+	})
+	s.Run("Tools includes toolset_enable", func() {
+		s.True(slices.ContainsFunc(receivedTools, func(t *schema.ToolInfo) bool { return t.Name == "toolset_enable" }), "Expected to find MCP 'toolset_enable' tool in received toolManager")
 	})
 }
 

--- a/pkg/ai/ai_prompt_test.go
+++ b/pkg/ai/ai_prompt_test.go
@@ -23,7 +23,7 @@ func (s *AiPromptSuite) SetupTest() {
 	s.Llm = &test.ChatModel{}
 	s.Ai = New(
 		test.NewInferenceProvider("inference-provider", test.WithInferenceAvailable(), test.WithInferenceLlm(s.Llm)),
-		[]api.ToolsProvider{test.NewToolsProvider("test-tools-provider", test.WithToolsAvailable())},
+		[]api.ToolsProvider{test.NewToolsProvider("test-toolManager-provider", test.WithToolsAvailable())},
 	)
 	if err := s.Ai.Run(config.WithConfig(s.T().Context(), config.New())); err != nil {
 		s.T().Fatalf("failed to run AI: %v", err)
@@ -51,13 +51,13 @@ func (s *AiPromptSuite) TestInput_SendsPrompt() {
 
 func (s *AiPromptSuite) TestInput_SendsPrompt_SetUpAgentError() {
 	s.Llm.WithToolsFunc = func(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
-		return s.Llm, errors.New("error setting up tools")
+		return s.Llm, errors.New("error setting up toolManager")
 	}
 	s.Ai.Input() <- api.NewUserMessage("I will trigger an error when setting up the prompt")
 	s.WaitForRunToComplete()
 	s.Run("Sets error message in session if agent setup fails", func() {
 		s.GreaterOrEqual(len(s.Ai.Session().Messages()), 1)
-		s.Contains(s.Ai.Session().Messages(), api.NewErrorMessage("error setting up tools"))
+		s.Contains(s.Ai.Session().Messages(), api.NewErrorMessage("error setting up toolManager"))
 	})
 }
 

--- a/pkg/ai/mcp.go
+++ b/pkg/ai/mcp.go
@@ -1,0 +1,160 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/eino-contrib/jsonschema"
+	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/version"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+)
+
+type ToolsProviderMcpClient struct {
+	api.ToolsProvider
+	*mcp.ClientSession
+}
+
+// Adaptation of https://github.com/cloudwego/eino-ext/blob/4a4306a8bf2cdae95b3e95bbe05b40fda0475fc2/components/tool/mcp/mcp.go
+// to deal with https://github.com/cloudwego/eino-ext/issues/436
+type mcpTool struct {
+	toolInfo *schema.ToolInfo
+	cli      *ToolsProviderMcpClient
+}
+
+var _ ToolManagerTool = &mcpTool{}
+
+func (m *mcpTool) ToolsProvider() api.ToolsProvider {
+	return m.cli.ToolsProvider
+}
+
+func (m *mcpTool) ToolInfo() *schema.ToolInfo {
+	return m.toolInfo
+}
+
+func (m *mcpTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return m.toolInfo, nil
+}
+
+func (m *mcpTool) InvokableRun(ctx context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	result, err := m.cli.CallTool(ctx, &mcp.CallToolParams{
+		Name:      m.toolInfo.Name,
+		Arguments: json.RawMessage(argumentsInJSON),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to call mcp tool: %w", err)
+	}
+
+	marshaledResult, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal mcp tool result: %w", err)
+	}
+	return string(marshaledResult), nil
+}
+
+func toMcpTools(ctx context.Context, cli *ToolsProviderMcpClient) ([]ToolManagerTool, error) {
+	listResults, err := cli.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		return nil, fmt.Errorf("list mcp toolManager fail: %w", err)
+	}
+
+	ret := make([]ToolManagerTool, 0, len(listResults.Tools))
+	for _, t := range listResults.Tools {
+		marshaledInputSchema, err := json.Marshal(t.InputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("conv mcp tool input schema fail(marshal): %w, tool name: %s", err, t.Name)
+		}
+		inputSchema := &jsonschema.Schema{}
+		err = json.Unmarshal(marshaledInputSchema, inputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("conv mcp tool input schema fail(unmarshal): %w, tool name: %s", err, t.Name)
+		}
+
+		ret = append(ret, &mcpTool{
+			toolInfo: &schema.ToolInfo{
+				Name:        t.Name,
+				Desc:        t.Description,
+				ParamsOneOf: schema.NewParamsOneOfByJSONSchema(inputSchema),
+			},
+			cli: cli,
+		})
+	}
+
+	return ret, nil
+}
+
+func ToMcpTools(ctx context.Context, mcpClients []*ToolsProviderMcpClient) (tools []ToolManagerTool) {
+	tools = make([]ToolManagerTool, 0)
+	for _, mcpClient := range mcpClients {
+		mcpTools, err := toMcpTools(ctx, mcpClient)
+		if err != nil {
+			// TODO: log error
+			continue
+		}
+		tools = append(tools, mcpTools...)
+	}
+	return tools
+}
+
+type HeaderRoundTripper struct {
+	headers map[string]string
+}
+
+func (h *HeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func StartMcpClients(ctx context.Context, toolsProviders []api.ToolsProvider) []*ToolsProviderMcpClient {
+	mcpClients := make([]*ToolsProviderMcpClient, 0, len(toolsProviders))
+	for _, toolProvider := range toolsProviders {
+		mcpSettings := toolProvider.GetMcpSettings()
+		if mcpSettings == nil {
+			continue
+		}
+		mcpClient := mcp.NewClient(&mcp.Implementation{Name: version.BinaryName + "-mcp-client", Version: version.Version}, nil)
+		var tr mcp.Transport
+		switch mcpSettings.Type {
+		case api.McpTypeStdio:
+			command := exec.CommandContext(ctx, mcpSettings.Command, mcpSettings.Args...)
+			command.Env = append(os.Environ(), mcpSettings.Env...)
+			tr = &mcp.CommandTransport{Command: command}
+		case api.McpTypeSse:
+			tr = &mcp.SSEClientTransport{
+				Endpoint: mcpSettings.Url,
+				HTTPClient: &http.Client{Transport: &HeaderRoundTripper{
+					headers: mcpSettings.Headers,
+				}},
+			}
+		case api.McpTypeStreamableHttp:
+			tr = &mcp.StreamableClientTransport{
+				Endpoint: mcpSettings.Url,
+				HTTPClient: &http.Client{Transport: &HeaderRoundTripper{
+					headers: mcpSettings.Headers,
+				}},
+			}
+		}
+		mcpSession, err := mcpClient.Connect(ctx, tr, nil)
+		if err != nil {
+			// TODO: log error
+			continue
+		}
+		mcpClients = append(mcpClients, &ToolsProviderMcpClient{ToolsProvider: toolProvider, ClientSession: mcpSession})
+	}
+	return mcpClients
+}
+
+func StopMcpClients(mcpClients []*ToolsProviderMcpClient) {
+	for _, mcpClient := range mcpClients {
+		_ = mcpClient.Close()
+	}
+}

--- a/pkg/ai/model.go
+++ b/pkg/ai/model.go
@@ -45,6 +45,7 @@ func (m *DynamicToolCallingChatModel) Stream(ctx context.Context, input []*schem
 }
 
 func (m *DynamicToolCallingChatModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
-	m.delegate, _ = m.delegate.WithTools(tools)
-	return m, nil
+	var err error
+	m.delegate, err = m.delegate.WithTools(tools)
+	return m, err
 }

--- a/pkg/ai/model.go
+++ b/pkg/ai/model.go
@@ -1,0 +1,50 @@
+package ai
+
+import (
+	"context"
+
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+)
+
+// DynamicToolCallingChatModel is a wrapper around model.ToolCallingChatModel that allows dynamic tool reloading.
+// Allows LLM model mutation to support dynamic tool reloading.
+type DynamicToolCallingChatModel struct {
+	delegate model.ToolCallingChatModel
+}
+
+var _ model.ToolCallingChatModel = (*DynamicToolCallingChatModel)(nil)
+
+func NewDynamicToolCallingChatModel(base model.ToolCallingChatModel, err error) (*DynamicToolCallingChatModel, error) {
+	if err != nil {
+		return nil, err
+	}
+	return &DynamicToolCallingChatModel{delegate: base}, nil
+}
+
+func (m *DynamicToolCallingChatModel) ReloadTools(ctx context.Context, tools []tool.BaseTool) (err error) {
+	infos := make([]*schema.ToolInfo, 0, len(tools))
+	for _, t := range tools {
+		info, e := t.Info(ctx)
+		if e != nil {
+			continue
+		}
+		infos = append(infos, info)
+	}
+	m.delegate, err = m.delegate.WithTools(infos)
+	return err
+}
+
+func (m *DynamicToolCallingChatModel) Generate(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	return m.delegate.Generate(ctx, input, opts...)
+}
+
+func (m *DynamicToolCallingChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	return m.delegate.Stream(ctx, input, opts...)
+}
+
+func (m *DynamicToolCallingChatModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	m.delegate, _ = m.delegate.WithTools(tools)
+	return m, nil
+}

--- a/pkg/ai/react.go
+++ b/pkg/ai/react.go
@@ -1,0 +1,93 @@
+package ai
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/charmbracelet/log"
+	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/flow/agent"
+	"github.com/cloudwego/eino/flow/agent/react"
+	"github.com/cloudwego/eino/schema"
+	callbackutils "github.com/cloudwego/eino/utils/callbacks"
+	"github.com/manusa/ai-cli/pkg/api"
+)
+
+const (
+	DefaultMaxSteps = 50
+)
+
+// ReActAgent is an agent that uses the ReAct framework to interact with the user and tools.
+// Currently, it's just wrapping around the standard react.Agent, but we might eventually want to fully implement
+// our own agent to have more control over the process and graph chain.
+type ReActAgent struct {
+	*react.Agent
+	ai *Ai
+}
+
+func NewReActAgent(ctx context.Context, ai *Ai) (agent *ReActAgent, err error) {
+	agent = &ReActAgent{ai: ai}
+	agent.Agent, err = react.NewAgent(ctx, &react.AgentConfig{
+		ToolCallingModel: ai.llm,
+		MaxStep:          DefaultMaxSteps,
+		ToolsConfig: compose.ToolsNodeConfig{
+			Tools:               ai.tools.EnabledTools(),
+			ExecuteSequentially: true,
+			UnknownToolsHandler: agent.unknownToolHandler,
+		},
+	})
+	if err != nil {
+		return
+	}
+	return
+}
+
+// unknownToolHandler is called when the model tries to call a tool that is not in the list of available tools.
+// This is a workaround because graph tool declarations are immutable after the graph is created and compiled.
+// The model might be actually calling a tool that was enabled after the graph was created (hence not unknown).
+//
+// The only issue is that standard callbacks are not called for unknown tools, so we manually call them here.
+func (r *ReActAgent) unknownToolHandler(ctx context.Context, name, input string) (string, error) {
+	r.OnToolCallStart(ctx, &callbacks.RunInfo{Name: name}, &tool.CallbackInput{ArgumentsInJSON: input})
+	defer r.OnToolCallEnd(ctx, &callbacks.RunInfo{Name: name}, &tool.CallbackOutput{})
+	return r.ai.tools.InvokeTool(ctx, name, input)
+}
+
+func (r *ReActAgent) OnChatModelStart(ctx context.Context, runInfo *callbacks.RunInfo, input *model.CallbackInput) context.Context {
+	// Reload the tools if the model is a DynamicToolCallingChatModel
+	// Enables dynamic tool reloading by replacing the delegate (immutable) model inside DynamicToolCallingChatModel
+	if runInfo.Type != reflect.TypeOf(DynamicToolCallingChatModel{}).Name() {
+		return ctx
+	}
+	_ = r.ai.llm.ReloadTools(ctx, r.ai.tools.EnabledTools())
+	return ctx
+}
+
+func (r *ReActAgent) OnToolCallStart(ctx context.Context, info *callbacks.RunInfo, input *tool.CallbackInput) context.Context {
+	log.Debug("calling tool", "name", info.Name, "input", input.ArgumentsInJSON)
+	return ctx
+}
+
+func (r *ReActAgent) OnToolCallEnd(ctx context.Context, info *callbacks.RunInfo, output *tool.CallbackOutput) context.Context {
+	log.Debug("called tool", "name", info.Name, "response", output.Response)
+	r.ai.appendMessage(api.NewToolMessage(output.Response, info.Name))
+	return ctx
+}
+
+func (r *ReActAgent) Stream(ctx context.Context) (*schema.StreamReader[*schema.Message], error) {
+	return r.Agent.Stream(
+		ctx,
+		r.ai.schemaMessages(),
+		agent.WithComposeOptions(compose.WithCallbacks(
+			callbackutils.NewHandlerHelper().ChatModel(&callbackutils.ModelCallbackHandler{
+				OnStart: r.OnChatModelStart,
+			}).Handler(),
+			callbackutils.NewHandlerHelper().Tool(&callbackutils.ToolCallbackHandler{
+				OnStart: r.OnToolCallStart,
+				OnEnd:   r.OnToolCallEnd,
+			}).Handler(),
+		)))
+}

--- a/pkg/ai/tools-manager.go
+++ b/pkg/ai/tools-manager.go
@@ -1,0 +1,105 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+)
+
+type ToolManager struct {
+	availableTools map[string]tool.InvokableTool
+	enabledTools   map[string]tool.InvokableTool
+	enableTool     *invokableTool
+}
+
+func NewToolManager(ctx context.Context, availableTools []tool.InvokableTool) *ToolManager {
+	availableToolsMap := make(map[string]tool.InvokableTool, len(availableTools))
+	toolNameParameter := strings.Builder{}
+	toolNameParameter.WriteString("The name of the tool or tools to enable.\n")
+	toolNameParameter.WriteString("You can enable multiple tools by separating their names with commas.\n")
+	toolNameParameter.WriteString("You can pick the tools from the following list (xml):\n<tools>\n")
+	for _, t := range availableTools {
+		info, err := t.Info(ctx)
+		if err != nil {
+			continue
+		}
+		availableToolsMap[info.Name] = t
+		toolNameParameter.WriteString(fmt.Sprintf(`<tool name="%s">%s</tool>`, info.Name, info.Desc) + "\n")
+	}
+	toolNameParameter.WriteString("\n</tools>")
+	toolManager := &ToolManager{
+		availableTools: availableToolsMap,
+		enabledTools:   make(map[string]tool.InvokableTool),
+	}
+	toolManager.enableTool = &invokableTool{
+		toolInfo: &schema.ToolInfo{
+			Name: "tool_enable",
+			Desc: "Enable a tool for the current session.",
+			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+				"tool_names": {
+					Type:     schema.String,
+					Desc:     toolNameParameter.String(),
+					Required: true,
+					Enum:     slices.Collect(maps.Keys(toolManager.availableTools)),
+				},
+			}),
+		},
+		function: toolManager.toolEnable,
+	}
+	toolManager.availableTools[toolManager.enableTool.toolInfo.Name] = toolManager.enableTool
+	return toolManager
+}
+
+func (t *ToolManager) ToolCount() int {
+	return len(t.enabledTools)
+}
+
+func (t *ToolManager) EnabledToolsReset() {
+	t.enabledTools = make(map[string]tool.InvokableTool)
+}
+
+func (t *ToolManager) EnabledTools() []tool.BaseTool {
+	ret := make([]tool.BaseTool, 0, len(t.enabledTools))
+	for _, enabledTool := range t.enabledTools {
+		ret = append(ret, enabledTool)
+	}
+	ret = append(ret, t.enableTool) // Always include the enable tool
+	return ret
+}
+
+func (t *ToolManager) InvokeTool(ctx context.Context, name, input string) (string, error) {
+	if enabledTool, exists := t.enabledTools[name]; exists {
+		return enabledTool.InvokableRun(ctx, input)
+	}
+	if _, exists := t.availableTools[name]; exists {
+		return fmt.Sprintf("Tool '%s' is not enabled. You can enable it by calling the 'tool_enable' tool first.", name), nil
+	}
+	return fmt.Sprintf("Tool '%s' not found.", name), nil
+}
+
+func (t *ToolManager) toolEnable(args map[string]interface{}) (string, error) {
+	toolNames, ok := args["tool_names"].(string)
+	if !ok {
+		return "Invalid tool names.", nil
+	}
+	sb := strings.Builder{}
+	for _, toolName := range strings.Split(toolNames, ",") {
+		toolName = strings.TrimSpace(toolName)
+		if _, exists := t.enabledTools[toolName]; exists {
+			sb.WriteString(fmt.Sprintf("Tool '%s' was already enabled.", toolName))
+			continue
+		}
+		if _, exists := t.availableTools[toolName]; !exists {
+			sb.WriteString(fmt.Sprintf("Tool '%s' not found.", toolName))
+			continue
+		}
+		t.enabledTools[toolName] = t.availableTools[toolName]
+		sb.WriteString(fmt.Sprintf("Tool '%s' enabled.", toolName))
+	}
+	return sb.String(), nil
+}

--- a/pkg/api/ai.go
+++ b/pkg/api/ai.go
@@ -2,6 +2,7 @@ package api
 
 type Ai interface {
 	InferenceAttributes() InferenceAttributes
+	ToolEnabledCount() int
 	ToolCount() int
 	Reset()
 	Session() Session

--- a/pkg/cmd/discover_test.go
+++ b/pkg/cmd/discover_test.go
@@ -64,7 +64,7 @@ func (s *DiscoverTestSuite) TestOutputText() {
 			"    Reason: filesystem is accessible\n" +
 			"Not Available Tools Providers:\n" +
 			"  - browsers\n" +
-			"    Description: Provides access to browsers\n" +
+			"    Description: Provides access to browser metadata such as bookmarks, search history, and so on\n" +
 			"    Reason: no browsers detected\n" +
 			"  - github\n" +
 			"    Description: Provides access to GitHub Platform. Provides the ability to to read repositories and code files, manage issues and PRs, analyze code, and automate workflows.\n" +
@@ -73,7 +73,7 @@ func (s *DiscoverTestSuite) TestOutputText() {
 			"    Description: Provides access to Kubernetes clusters, allowing management and interaction with cluster resources.\n" +
 			"    Reason: no suitable MCP settings found for the Kubernetes MCP server\n" +
 			"  - playwright\n" +
-			"    Description: Automate and interact with web browsers using Playwright.\n" +
+			"    Description: Enables web browsing capabilities through Playwright. Opening web pages, opening URLs, interacting with elements inside the browser, extracting snapshots, and scraping information from web pages. Support for multiple tabs and many other browser options\n" +
 			"    Reason: npx command not found\n" +
 			"  - postgresql\n" +
 			"    Description: Provides access to a PostgreSQL database, allowing execution of SQL queries and retrieval of data.\n" +
@@ -101,10 +101,10 @@ func (s *DiscoverTestSuite) TestOutputJson() {
 			`"tools":[` +
 			`{"description":"Provides access to the local filesystem, allowing listing of files and directories.","name":"fs","reason":"filesystem is accessible"}],` +
 			`"toolsNotAvailable":[` +
-			`{"description":"Provides access to browsers","name":"browsers","reason":"no browsers detected"},` +
+			`{"description":"Provides access to browser metadata such as bookmarks, search history, and so on","name":"browsers","reason":"no browsers detected"},` +
 			`{"description":"Provides access to GitHub Platform. Provides the ability to to read repositories and code files, manage issues and PRs, analyze code, and automate workflows.","name":"github","reason":"GITHUB_PERSONAL_ACCESS_TOKEN is not set"},` +
 			`{"description":"Provides access to Kubernetes clusters, allowing management and interaction with cluster resources.","name":"kubernetes","reason":"no suitable MCP settings found for the Kubernetes MCP server"},` +
-			`{"description":"Automate and interact with web browsers using Playwright.","name":"playwright","reason":"npx command not found"},` +
+			`{"description":"Enables web browsing capabilities through Playwright. Opening web pages, opening URLs, interacting with elements inside the browser, extracting snapshots, and scraping information from web pages. Support for multiple tabs and many other browser options","name":"playwright","reason":"npx command not found"},` +
 			`{"description":"Provides access to a PostgreSQL database, allowing execution of SQL queries and retrieval of data.","name":"postgresql","reason":"no suitable MCP settings found for the PostgreSQL MCP server"}` +
 			`]}`
 		s.JSONEq(expectedOutput, output, "Expected JSON output does not match")

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -49,8 +49,8 @@ func (p *Provider) GetInference(ctx context.Context) (model.ToolCallingChatModel
 func (p *Provider) SystemPrompt() string {
 	// Adapted from https://github.com/google-gemini/gemini-cli/blob/5c2bb990d895254e6563acfd26946c389125387f/packages/core/src/core/prompts.ts#L50
 	return fmt.Sprintf(`
-You are an interactive CLI agent specializing in software engineering and other generic tasks.
-Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions, company policies, and utilizing your available tools.
+You are an interactive CLI agent specializing in general tasks.
+Your primary goal is to help users safely and efficiently, adhering to the following instructions, company policies, and utilizing your available tools that you can enable at any time.
 Today is %s.
 
 # Core Mandates
@@ -74,7 +74,13 @@ Today is %s.
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Catalogue:** You are presented with a catalogue of available tools. You can enable any tool you deem useful to fulfill the user's request at any time.
+- **Tool Enabling:** Tools need to be enabled, you don't need to ask for permission to enable a tool. Enable the tool you consider most appropriate for the task and continue with the task **No Chitchat**. You can enable tools at any time.
 - **Parallelism:** Tools are executed sequentially. You may request multiple tool calls, but they will be executed one at a time in the order you provide.
+
+## URL handling
+- **Browsing:** You have access to a web browsing tool. Enable it when user asks to open a URL.
+- **URL Extraction:** When the user provides a URL, it might be incomplete, try to infer the complete URL (e.g. prepend the protocol 'https://').
 
 	`, time.Now().Format("January 2, 2006"))
 }

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -65,7 +65,7 @@ Today is %s.
 - **Minimal Output:** Aim for fewer than 3 lines of text output (excluding tool use/code generation) per response whenever practical. Focus strictly on the user's query.
 - **Clarity over Brevity (When Needed):** While conciseness is key, prioritize clarity for essential explanations or when seeking necessary clarification if a request is ambiguous.
 - **No Chitchat:** Avoid conversational filler, preambles ("Okay, I will now..."), or postambles ("I have finished the changes..."). Get straight to the action or answer.
-- **Formatting:** Use GitHub-flavored Markdown. Responses will be rendered in monospace.
+- **Formatting:** Use GitHub-flavored Markdown. Responses will be rendered in monospace. You are able to convert structured output (e.g. JSON, XML, YAML, CSV, etc.) into Markdown or other convenient formats for better readability. Remember to surround code blocks with triple backticks and specify the language when appropriate (e.g., `+"```json"+`).
 - **Tools vs. Text:** Use tools for actions, text output *only* for communication. Do not add explanatory comments within tool calls or code blocks unless specifically part of the required code/command itself.
 - **Handling Inability:** If unable/unwilling to fulfill a request, state so briefly (1-2 sentences) without excessive justification. Offer alternatives if appropriate.
 

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -23,9 +23,15 @@ var (
 	// DefaultBaseURL is the default base URL for the Ollama API (Exposed for testing purposes)
 	DefaultBaseURL  = "http://localhost:11434"
 	preferredModels = []string{
-		"llama3.2:3b",
-		"granite3.3:latest",
-		"mistral:7b",
+		"gpt-oss:20b",                   // ✅ Works extremely well, but is slow
+		"llama3.2:3b",                   // ❌ Can't enable tools, confuses parameters of the different tools available
+		"llama3.1:8b",                   // Manages to enable tools, but hallucinates tool outputs.
+		"qwen3:4b-instruct-2507-q4_K_M", // With No Thinking (which is required) won't execute tools (seems error in ollama)
+		"qwen3:8b",                      // With No Thinking (which is required) won't execute tools (seems error in ollama)
+		"mistral:7b",                    // ❌ Doesn't perform tool calls
+		"deepseek-r1:8b",                // ❌ Doesn't support tool calls ??? https://github.com/ollama/ollama/issues/8517 https://github.com/ollama/ollama/issues/10912
+		"deepseek-r1:7b",                // ❌ Doesn't support tool calls ???
+		"granite3.3:latest",             // ❌ Doesn't work at all
 	}
 )
 
@@ -97,6 +103,7 @@ func (p *Provider) GetInference(ctx context.Context) (model.ToolCallingChatModel
 	return ollama.NewChatModel(ctx, &ollama.ChatModelConfig{
 		BaseURL: p.baseURL(),
 		Model:   *p.Model,
+		//Thinking: &ollamaapi.ThinkValue{Value: false},
 	})
 }
 

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -23,15 +23,15 @@ var (
 	// DefaultBaseURL is the default base URL for the Ollama API (Exposed for testing purposes)
 	DefaultBaseURL  = "http://localhost:11434"
 	preferredModels = []string{
-		"gpt-oss:20b",                   // ✅ Works extremely well, but is slow
-		"llama3.2:3b",                   // ❌ Can't enable tools, confuses parameters of the different tools available
-		"llama3.1:8b",                   // Manages to enable tools, but hallucinates tool outputs.
-		"qwen3:4b-instruct-2507-q4_K_M", // With No Thinking (which is required) won't execute tools (seems error in ollama)
-		"qwen3:8b",                      // With No Thinking (which is required) won't execute tools (seems error in ollama)
-		"mistral:7b",                    // ❌ Doesn't perform tool calls
-		"deepseek-r1:8b",                // ❌ Doesn't support tool calls ??? https://github.com/ollama/ollama/issues/8517 https://github.com/ollama/ollama/issues/10912
-		"deepseek-r1:7b",                // ❌ Doesn't support tool calls ???
-		"granite3.3:latest",             // ❌ Doesn't work at all
+		"gpt-oss:20b", // ✅ Works extremely well, but is slow
+		"llama3.2:3b", // ❌ Can't enable tools, confuses parameters of the different tools available
+		"llama3.1:8b", // Manages to enable tools, but hallucinates tool outputs.
+		// "qwen3:4b-instruct-2507-q4_K_M", // With No Thinking (which is required) won't execute tools (seems error in ollama)
+		// "qwen3:8b",                      // With No Thinking (which is required) won't execute tools (seems error in ollama)
+		// "mistral:7b",                    // ❌ Doesn't perform tool calls
+		// "deepseek-r1:8b",                // ❌ Doesn't support tool calls ??? https://github.com/ollama/ollama/issues/8517 https://github.com/ollama/ollama/issues/10912
+		// "deepseek-r1:7b",                // ❌ Doesn't support tool calls ???
+		// "granite3.3:latest",             // ❌ Doesn't work at all
 	}
 )
 

--- a/pkg/inference/ollama/ollama_test.go
+++ b/pkg/inference/ollama/ollama_test.go
@@ -109,7 +109,7 @@ func (s *OllamaTestSuite) TestInitializeWithCompatibleServerMissingModel() {
 			s.False(instance.IsAvailable())
 		})
 		s.Run("shows reason", func() {
-			s.Equal(fmt.Sprintf("ollama is accessible at %s defined by the OLLAMA_HOST environment variable but no preferred models (llama3.2:3b, granite3.3:latest, mistral:7b) are served", s.MockServer.URL()), instance.Reason())
+			s.Equal(fmt.Sprintf("ollama is accessible at %s defined by the OLLAMA_HOST environment variable but no preferred models (gpt-oss:20b, llama3.2:3b, llama3.1:8b) are served", s.MockServer.URL()), instance.Reason())
 		})
 		s.Run("has models", func() {
 			s.Len(instance.Models(), 2)
@@ -128,7 +128,7 @@ func (s *OllamaTestSuite) TestInitializeWithCompatibleServerMissingModel() {
 					`"models":["model-1", "model-2"],`+
 					`"name":"ollama",`+
 					`"public":false,`+
-					fmt.Sprintf(`"reason":"ollama is accessible at %s defined by the OLLAMA_HOST environment variable but no preferred models (llama3.2:3b, granite3.3:latest, mistral:7b) are served"`, s.MockServer.URL())+
+					fmt.Sprintf(`"reason":"ollama is accessible at %s defined by the OLLAMA_HOST environment variable but no preferred models (gpt-oss:20b, llama3.2:3b, llama3.1:8b) are served"`, s.MockServer.URL())+
 					`}`, string(data))
 			})
 		})

--- a/pkg/tools/browsers/browsers.go
+++ b/pkg/tools/browsers/browsers.go
@@ -55,7 +55,7 @@ var instance = &Provider{
 		BasicToolsAttributes: api.BasicToolsAttributes{
 			BasicFeatureAttributes: api.BasicFeatureAttributes{
 				FeatureName:        "browsers",
-				FeatureDescription: "Provides access to browsers",
+				FeatureDescription: "Provides access to browser metadata such as bookmarks, search history, and so on",
 			},
 		},
 	},

--- a/pkg/tools/playwright/playwright.go
+++ b/pkg/tools/playwright/playwright.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TODO: Centralize version management elsewhere
-const version = "0.0.36"
+const version = "0.0.40"
 
 type Provider struct {
 	api.BasicToolsProvider
@@ -42,8 +42,10 @@ var instance = &Provider{
 	BasicToolsProvider: api.BasicToolsProvider{
 		BasicToolsAttributes: api.BasicToolsAttributes{
 			BasicFeatureAttributes: api.BasicFeatureAttributes{
-				FeatureName:        "playwright",
-				FeatureDescription: "Automate and interact with web browsers using Playwright.",
+				FeatureName: "playwright",
+				FeatureDescription: "Enables web browsing capabilities through Playwright. " +
+					"Opening web pages, opening URLs, interacting with elements inside the browser, extracting snapshots, and scraping information from web pages. " +
+					"Support for multiple tabs and many other browser options",
 			},
 		},
 	},

--- a/pkg/tools/playwright/playwright_test.go
+++ b/pkg/tools/playwright/playwright_test.go
@@ -34,7 +34,10 @@ func (s *PlaywrightTestSuite) TestFeatureAttributes() {
 		s.Equal("playwright", instance.FeatureName)
 	})
 	s.Run("has feature description", func() {
-		s.Equal("Automate and interact with web browsers using Playwright.", instance.FeatureDescription)
+		s.Equal("Enables web browsing capabilities through Playwright. "+
+			"Opening web pages, opening URLs, interacting with elements inside the browser, extracting snapshots, and scraping information from web pages. "+
+			"Support for multiple tabs and many other browser options",
+			instance.FeatureDescription)
 	})
 }
 
@@ -64,7 +67,7 @@ func (s *PlaywrightTestSuite) TestInitializeWithNodeAndDesktop() {
 	})
 	s.Run("sets MCP settings", func() {
 		s.Equal("npx", feats.Tools[0].(*Provider).McpSettings.Command)
-		s.Equal([]string{"-y", "@playwright/mcp@0.0.36"}, feats.Tools[0].(*Provider).McpSettings.Args)
+		s.Equal([]string{"-y", "@playwright/mcp@0.0.40"}, feats.Tools[0].(*Provider).McpSettings.Args)
 	})
 }
 
@@ -76,7 +79,7 @@ func (s *PlaywrightTestSuite) TestInitializeWithNodeAndNoDesktop() {
 	s.Require().Empty(feats.ToolsNotAvailable)
 	s.Run("sets MCP settings with headless", func() {
 		s.Equal("npx", feats.Tools[0].(*Provider).McpSettings.Command)
-		s.Equal([]string{"-y", "@playwright/mcp@0.0.36", "--headless"}, feats.Tools[0].(*Provider).McpSettings.Args)
+		s.Equal([]string{"-y", "@playwright/mcp@0.0.40", "--headless"}, feats.Tools[0].(*Provider).McpSettings.Args)
 	})
 }
 

--- a/pkg/ui/components/footer/footer.go
+++ b/pkg/ui/components/footer/footer.go
@@ -1,7 +1,7 @@
 package footer
 
 import (
-	"strconv"
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
@@ -28,8 +28,8 @@ func (m model) View() string {
 		Background(m.ctx.Theme.FooterBackground).
 		Foreground(m.ctx.Theme.FooterText).
 		Padding(0, 1)
-	left := style.Render("🧠", m.ctx.Ai.InferenceAttributes().Name(),
-		"🛠️", strconv.Itoa(m.ctx.Ai.ToolCount()))
+	left := style.Render(fmt.Sprintf("🧠 %s", m.ctx.Ai.InferenceAttributes().Name()),
+		fmt.Sprintf("🛠 %d/%d", m.ctx.Ai.ToolEnabledCount(), m.ctx.Ai.ToolCount()))
 	version := style.Render(m.ctx.Version)
 	spacerWidth := m.ctx.Width - lipgloss.Width(left) - lipgloss.Width(version)
 	if spacerWidth < 0 {

--- a/pkg/ui/model_test.go
+++ b/pkg/ui/model_test.go
@@ -283,7 +283,7 @@ func (s *ModelSuite) TestFooter() {
 	s.Run("Footer displays tools provider count", func() {
 		s.Repaint()
 		teatest.WaitFor(s.T(), s.TM.Output(), func(b []byte) bool {
-			return strings.Contains(string(b), "🛠️ 1")
+			return strings.Contains(string(b), "🛠 0/1")
 		})
 	})
 }


### PR DESCRIPTION
- enables the LLM to enable toolsets based on the needs of the user for a specific prompt.
- modifies toolset descriptions to make them more friendly to LLMs.
- refactors mcp client to go-sdk to prevent an issue with mcp-go (m3labs) and buffer overflow
- additional tests and further refactoring will be added as follow-up