### PR TITLE
feat: check in keyring if gemini api key is stored

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/feloy/browsers-mcp-server v0.0.4
 	github.com/google/jsonschema-go v0.3.0
 	github.com/google/uuid v1.6.0
+	github.com/keybase/go-keychain v0.0.1
 	github.com/modelcontextprotocol/go-sdk v0.8.0
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/afero v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"os"
-
 	"github.com/manusa/ai-cli/pkg/api"
 )
 
@@ -30,9 +28,7 @@ type Config struct {
 	InferenceConfig InferenceConfig `toml:"inferences,omitempty"`
 	toolsConfig     ToolsConfig     `toml:"tools,omitempty"`
 
-	policies     *api.Policies // TODO: should be removed in favor of ToolsConfig and InferenceConfig above
-	googleApiKey string        // TODO: will likely be removed
-	geminiModel  string        // TODO: will likely be removed
+	policies *api.Policies // TODO: should be removed in favor of ToolsConfig and InferenceConfig above
 }
 
 // New creates a new configuration with defaults
@@ -44,8 +40,6 @@ type Config struct {
 //	3) The merged configuration is restricted/enforced by the policies Config.Enforce
 func New() *Config {
 	return &Config{
-		googleApiKey: os.Getenv("GEMINI_API_KEY"),
-		geminiModel:  "gemini-2.0-flash",
 		InferenceConfig: InferenceConfig{
 			InferenceParameters: api.InferenceParameters{
 				// By default, all inference providers are enabled
@@ -64,14 +58,6 @@ func New() *Config {
 			Provider: make(map[string]api.ToolsParameters),
 		},
 	}
-}
-
-func (c *Config) GoogleApiKey() string {
-	return c.googleApiKey
-}
-
-func (c *Config) GeminiModel() string {
-	return c.geminiModel
 }
 
 func (c *Config) Inference() *string {

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -51,7 +51,7 @@ func (p *Provider) GetInference(ctx context.Context) (model.ToolCallingChatModel
 }
 
 func (p *Provider) getApiKey() string {
-	if key, err := keyring.GetKey(API_KEY_ENV_VAR); err == nil {
+	if key, err := keyring.GetKey(API_KEY_ENV_VAR); err == nil && len(key) > 0 {
 		return key
 	}
 	return os.Getenv(API_KEY_ENV_VAR)

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -19,6 +19,10 @@ type Provider struct {
 	api.BasicInferenceProvider
 }
 
+const (
+	API_KEY_ENV_VAR = "GEMINI_API_KEY"
+)
+
 var _ api.InferenceProvider = &Provider{}
 
 func (p *Provider) Initialize(ctx context.Context) {
@@ -29,10 +33,10 @@ func (p *Provider) Initialize(ctx context.Context) {
 
 	p.Available = p.getApiKey() != ""
 	if p.Available {
-		p.IsAvailableReason = "GEMINI_API_KEY is set"
+		p.IsAvailableReason = fmt.Sprintf("%s is set", API_KEY_ENV_VAR)
 		p.ProviderModels = []string{"gemini-2.0-flash"}
 	} else {
-		p.IsAvailableReason = "GEMINI_API_KEY is not set"
+		p.IsAvailableReason = fmt.Sprintf("%s is not set", API_KEY_ENV_VAR)
 	}
 }
 
@@ -47,10 +51,10 @@ func (p *Provider) GetInference(ctx context.Context) (model.ToolCallingChatModel
 }
 
 func (p *Provider) getApiKey() string {
-	if key, err := keyring.GetKey("GEMINI_API_KEY"); err == nil {
+	if key, err := keyring.GetKey(API_KEY_ENV_VAR); err == nil {
 		return key
 	}
-	return os.Getenv("GEMINI_API_KEY")
+	return os.Getenv(API_KEY_ENV_VAR)
 }
 
 func (p *Provider) SystemPrompt() string {

--- a/pkg/inference/gemini/gemini_test.go
+++ b/pkg/inference/gemini/gemini_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/manusa/ai-cli/internal/test"
 	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/manusa/ai-cli/pkg/keyring"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,6 +21,7 @@ type GeminiTestSuite struct {
 }
 
 func (s *GeminiTestSuite) SetupTest() {
+	keyring.MockInit()
 	s.originalEnv = os.Environ()
 	os.Clearenv()
 	s.ctx = config.WithConfig(s.T().Context(), config.New())

--- a/pkg/inference/gemini/gemini_test.go
+++ b/pkg/inference/gemini/gemini_test.go
@@ -31,6 +31,8 @@ func (s *GeminiTestSuite) TearDownTest() {
 }
 
 func (s *GeminiTestSuite) TestInitializeWithNoAPIKey() {
+	// assert that an empty key stored in the ring is not taken into consideration
+	_ = keyring.SetKey("GEMINI_API_KEY", "")
 	instance.Initialize(s.ctx)
 	s.Run("when GEMINI_API_KEY is not set, is not available", func() {
 		s.False(instance.IsAvailable())
@@ -61,9 +63,41 @@ func (s *GeminiTestSuite) TestInitializeWithNoAPIKey() {
 }
 
 func (s *GeminiTestSuite) TestInitializeWithAPIKey() {
+	// assert that an empty key stored in the ring is not taken into consideration
+	_ = keyring.SetKey("GEMINI_API_KEY", "")
 	_ = os.Setenv("GEMINI_API_KEY", "A_VALID_KEY")
-	ctxWithApiKey := config.WithConfig(s.ctx, config.New())
-	instance.Initialize(ctxWithApiKey)
+	instance.Initialize(s.ctx)
+	s.Run("when GEMINI_API_KEY is set, is available", func() {
+		s.True(instance.IsAvailable())
+	})
+	s.Run("when GEMINI_API_KEY is set, shows reason", func() {
+		s.Equal("GEMINI_API_KEY is set", instance.Reason())
+	})
+	s.Run("when GEMINI_API_KEY is set, has models", func() {
+		s.Len(instance.Models(), 1)
+		s.Contains(instance.Models(), "gemini-2.0-flash")
+	})
+	s.Run("when GEMINI_API_KEY is set, marshaled JSON shows availability fields", func() {
+		data, err := json.Marshal(instance)
+		s.Run("does not return an error", func() {
+			s.Nil(err)
+		})
+		s.Run("returns expected JSON", func() {
+			s.JSONEq(`{`+
+				`"description":"Google Gemini inference provider",`+
+				`"local":false,`+
+				`"models":["gemini-2.0-flash"],`+
+				`"name":"gemini",`+
+				`"public":true,`+
+				`"reason":"GEMINI_API_KEY is set"`+
+				`}`, string(data))
+		})
+	})
+}
+
+func (s *GeminiTestSuite) TestInitializeWithAPIKeyFromKeyring() {
+	_ = keyring.SetKey("GEMINI_API_KEY", "A_VALID_KEY")
+	instance.Initialize(s.ctx)
 	s.Run("when GEMINI_API_KEY is set, is available", func() {
 		s.True(instance.IsAvailable())
 	})

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -1,19 +1,16 @@
 package keyring
 
-import "github.com/keybase/go-keychain"
+var provider Keyring = &fallbackKeyring{}
 
-const (
-	service = "com.redhat.ai-cli"
-)
-
-func GetKey(key string) (string, error) {
-	password, err := keychain.GetGenericPassword(service, key, "", "")
-	return string(password), err
+type Keyring interface {
+	SetKey(key, value string) error
+	GetKey(key string) (string, error)
 }
 
 func SetKey(key, value string) error {
-	item := keychain.NewGenericPassword(service, key, "", []byte(value), "")
-	item.SetSynchronizable(keychain.SynchronizableNo)
-	item.SetAccessible(keychain.AccessibleWhenUnlocked)
-	return keychain.AddItem(item)
+	return provider.SetKey(key, value)
+}
+
+func GetKey(key string) (string, error) {
+	return provider.GetKey(key)
 }

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -1,0 +1,19 @@
+package keyring
+
+import "github.com/keybase/go-keychain"
+
+const (
+	service = "com.redhat.ai-cli"
+)
+
+func GetKey(key string) (string, error) {
+	password, err := keychain.GetGenericPassword(service, key, "", "")
+	return string(password), err
+}
+
+func SetKey(key, value string) error {
+	item := keychain.NewGenericPassword(service, key, "", []byte(value), "")
+	item.SetSynchronizable(keychain.SynchronizableNo)
+	item.SetAccessible(keychain.AccessibleWhenUnlocked)
+	return keychain.AddItem(item)
+}

--- a/pkg/keyring/keyring_darwin.go
+++ b/pkg/keyring/keyring_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+// +build darwin
+
+package keyring
+
+import "github.com/keybase/go-keychain"
+
+const (
+	service = "com.redhat.ai-cli"
+)
+
+type macOSXKeychain struct{}
+
+var _ Keyring = &macOSXKeychain{}
+
+func (k *macOSXKeychain) GetKey(key string) (string, error) {
+	password, err := keychain.GetGenericPassword(service, key, "", "")
+	return string(password), err
+}
+
+func (k *macOSXKeychain) SetKey(key, value string) error {
+	item := keychain.NewGenericPassword(service, key, "", []byte(value), "")
+	item.SetSynchronizable(keychain.SynchronizableNo)
+	item.SetAccessible(keychain.AccessibleWhenUnlocked)
+	return keychain.AddItem(item)
+}
+
+func init() {
+	provider = &macOSXKeychain{}
+}

--- a/pkg/keyring/keyring_fallback.go
+++ b/pkg/keyring/keyring_fallback.go
@@ -1,0 +1,15 @@
+package keyring
+
+import "errors"
+
+type fallbackKeyring struct{}
+
+var _ Keyring = &fallbackKeyring{}
+
+func (k *fallbackKeyring) GetKey(key string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (k *fallbackKeyring) SetKey(key, value string) error {
+	return errors.New("not implemented")
+}

--- a/pkg/keyring/keyring_mock.go
+++ b/pkg/keyring/keyring_mock.go
@@ -2,18 +2,26 @@ package keyring
 
 import "errors"
 
-type mockProvider struct{}
+type mockProvider struct {
+	keys map[string]string
+}
 
 var _ Keyring = &mockProvider{}
 
 func (k *mockProvider) GetKey(key string) (string, error) {
-	return "", errors.New("not implemented")
+	if value, ok := k.keys[key]; ok {
+		return value, nil
+	}
+	return "", errors.New("key not found")
 }
 
 func (k *mockProvider) SetKey(key, value string) error {
-	return errors.New("not implemented")
+	k.keys[key] = value
+	return nil
 }
 
 func MockInit() {
-	provider = &mockProvider{}
+	provider = &mockProvider{
+		keys: make(map[string]string),
+	}
 }

--- a/pkg/keyring/keyring_mock.go
+++ b/pkg/keyring/keyring_mock.go
@@ -1,0 +1,19 @@
+package keyring
+
+import "errors"
+
+type mockProvider struct{}
+
+var _ Keyring = &mockProvider{}
+
+func (k *mockProvider) GetKey(key string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (k *mockProvider) SetKey(key, value string) error {
+	return errors.New("not implemented")
+}
+
+func MockInit() {
+	provider = &mockProvider{}
+}


### PR DESCRIPTION
Fetch GEMINI_API_KEY from keyring, before to check the env var.

To test it (macOS):

- do not define env var GEMINI_API_KEY
- set your API key in keyring: `security add-generic-password -s com.redhat.ai-cli -a GEMINI_API_KEY -w your_api_key
- run `ai-cli discover` and/or `ai-cli chat`

(follow-up PR will save the api key in the keyring during `ai-cli setup`)

On Linux/Windows, nothing should have changed, the keyring will be ignored, as not being implemented