### PR TITLE
feat: keyring on linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a h1:K0EAzgzEQHW4Y5lxrmvPMltmlRDzlhLfGmots9EHUTI=
+github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a/go.mod h1:YPNKjjE7Ubp9dTbnWvsP3HT+hYnY6TfXzubYTBeUxc8=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/pkg/keyring/keyring_linux.go
+++ b/pkg/keyring/keyring_linux.go
@@ -1,0 +1,85 @@
+//go:build linux
+// +build linux
+
+package keyring
+
+import (
+	"errors"
+
+	"github.com/keybase/go-keychain/secretservice"
+)
+
+const (
+	service = "com.redhat.ai-cli"
+)
+
+type linuxKeychain struct{}
+
+var _ Keyring = &linuxKeychain{}
+
+func (k *linuxKeychain) GetKey(key string) (string, error) {
+	srv, err := secretservice.NewService()
+	if err != nil {
+		return "", err
+	}
+	collection := secretservice.DefaultCollection
+	items, err := srv.SearchCollection(collection, map[string]string{
+		"key":     key,
+		"service": service,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(items) == 0 {
+		return "", errors.New("password not found")
+	}
+	if len(items) > 1 {
+		return "", errors.New("more than one password found, should not happen")
+	}
+
+	session, err := srv.OpenSession(secretservice.AuthenticationDHAES)
+	if err != nil {
+		return "", err
+	}
+	defer srv.CloseSession(session)
+
+	secret, err := srv.GetSecret(items[0], *session)
+	if err != nil {
+		return "", err
+	}
+	return string(secret), nil
+}
+
+func (k *linuxKeychain) SetKey(key, value string) error {
+	srv, err := secretservice.NewService()
+	if err != nil {
+		return err
+	}
+	session, err := srv.OpenSession(secretservice.AuthenticationDHAES)
+	if err != nil {
+		return err
+	}
+	defer srv.CloseSession(session)
+
+	collection := secretservice.DefaultCollection
+
+	secret, err := session.NewSecret([]byte(value))
+	if err != nil {
+		return err
+	}
+
+	_, err = srv.CreateItem(
+		collection,
+		secretservice.NewSecretProperties("Gemini API Key for ai-cli", map[string]string{
+			"key":     key,
+			"service": service,
+		}),
+		secret,
+		secretservice.ReplaceBehaviorReplace,
+	)
+	return err
+}
+
+func init() {
+	provider = &linuxKeychain{}
+}


### PR DESCRIPTION
adds implementation of keyring package on Linux

to test (fedora/gonme): run `ai-cli setup` and follow the instructions for gemini.

A password should be stored in the passwords manager, and you should be able to start `ai-cli chat` .