### PR TITLE
feat: github setup

### DIFF
--- a/pkg/api/features.go
+++ b/pkg/api/features.go
@@ -21,12 +21,15 @@ type FeatureAttributes interface {
 	Name() string
 	// Description of the feature
 	Description() string
+	// SupportsSetup indicates if the inference provider supports setup
+	SupportsSetup() bool
 }
 
 type BasicFeatureAttributes struct {
 	FeatureAttributes  `json:"-"`
 	FeatureName        string `json:"name"`
 	FeatureDescription string `json:"description"`
+	SupportsSetupAttr  bool   `json:"-"`
 }
 
 func (a *BasicFeatureAttributes) Name() string {
@@ -35,6 +38,10 @@ func (a *BasicFeatureAttributes) Name() string {
 
 func (a *BasicFeatureAttributes) Description() string {
 	return a.FeatureDescription
+}
+
+func (a *BasicFeatureAttributes) SupportsSetup() bool {
+	return a.SupportsSetupAttr
 }
 
 type IsFeatureEnabled[a FeatureAttributes] func(feature Feature[a]) bool

--- a/pkg/api/inference.go
+++ b/pkg/api/inference.go
@@ -23,8 +23,6 @@ type InferenceAttributes interface {
 	Local() bool
 	// Public indicates if the inference provider is public (e.g. OpenAI, Gemini) or private (e.g. Enterprise internal)
 	Public() bool
-	// SupportsSetup indicates if the inference provider supports setup
-	SupportsSetup() bool
 }
 
 type InferenceParameters struct {
@@ -61,6 +59,10 @@ func (p *BasicInferenceProvider) SystemPrompt() string {
 	return ""
 }
 
+func (a *BasicInferenceProvider) InstallHelp() error {
+	return nil
+}
+
 func (p *BasicInferenceProvider) GetModel(ctx context.Context) (string, error) {
 	if p.Model == nil {
 		return "", fmt.Errorf("no model found")
@@ -70,9 +72,8 @@ func (p *BasicInferenceProvider) GetModel(ctx context.Context) (string, error) {
 
 type BasicInferenceAttributes struct {
 	BasicFeatureAttributes
-	LocalAttr         bool `json:"local"`
-	PublicAttr        bool `json:"public"`
-	SupportsSetupAttr bool `json:"-"`
+	LocalAttr  bool `json:"local"`
+	PublicAttr bool `json:"public"`
 }
 
 func (a *BasicInferenceAttributes) Local() bool {
@@ -81,8 +82,4 @@ func (a *BasicInferenceAttributes) Local() bool {
 
 func (a *BasicInferenceAttributes) Public() bool {
 	return a.PublicAttr
-}
-
-func (a *BasicInferenceAttributes) SupportsSetup() bool {
-	return a.SupportsSetupAttr
 }

--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -13,6 +13,7 @@ type ToolsProvider interface {
 	GetMcpSettings() *McpSettings
 	// GetTools returns the list of built-in, native, available tools
 	GetTools(ctx context.Context) []*Tool
+	InstallHelp() error
 }
 
 type ToolsAttributes interface {
@@ -54,6 +55,10 @@ func (p *BasicToolsProvider) GetMcpSettings() *McpSettings {
 }
 
 func (p *BasicToolsProvider) GetTools(_ context.Context) []*Tool {
+	return nil
+}
+
+func (p *BasicToolsProvider) InstallHelp() error {
 	return nil
 }
 

--- a/pkg/inference/gemini/gemini.go
+++ b/pkg/inference/gemini/gemini.go
@@ -119,10 +119,10 @@ var instance = &Provider{
 			BasicFeatureAttributes: api.BasicFeatureAttributes{
 				FeatureName:        "gemini",
 				FeatureDescription: "Google Gemini inference provider",
+				SupportsSetupAttr:  true,
 			},
-			LocalAttr:         false,
-			PublicAttr:        true,
-			SupportsSetupAttr: true,
+			LocalAttr:  false,
+			PublicAttr: true,
 		},
 	},
 }

--- a/pkg/inference/lmstudio/lmstudio.go
+++ b/pkg/inference/lmstudio/lmstudio.go
@@ -92,10 +92,6 @@ func (p *Provider) baseURL() string {
 	return defaultBaseURL
 }
 
-func (p *Provider) InstallHelp() error {
-	return nil
-}
-
 var instance = &Provider{
 	BasicInferenceProvider: api.BasicInferenceProvider{
 		BasicInferenceAttributes: api.BasicInferenceAttributes{

--- a/pkg/inference/ollama/ollama.go
+++ b/pkg/inference/ollama/ollama.go
@@ -142,10 +142,6 @@ func (p *Provider) isBaseURLConfigured() bool {
 	return os.Getenv(ollamaHostEnvVar) != ""
 }
 
-func (p *Provider) InstallHelp() error {
-	return nil
-}
-
 var instance = &Provider{
 	api.BasicInferenceProvider{
 		BasicInferenceAttributes: api.BasicInferenceAttributes{

--- a/pkg/inference/ramalama/ramalama.go
+++ b/pkg/inference/ramalama/ramalama.go
@@ -103,10 +103,6 @@ func (p *Provider) getRamalamaBinaryName() string {
 	return "ramalama"
 }
 
-func (p *Provider) InstallHelp() error {
-	return nil
-}
-
 var instance = &Provider{
 	api.BasicInferenceProvider{
 		BasicInferenceAttributes: api.BasicInferenceAttributes{

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Run(ctx context.Context) error {
-	for {
+	for { // setup inference
 		discoveredFeatures := features.Discover(ctx)
 		if discoveredFeatures.Inference == nil {
 			err := selectInferenceProvider(ctx)
@@ -29,6 +29,21 @@ func Run(ctx context.Context) error {
 				fmt.Printf("✅ The model %q will be used\n", model)
 				break
 			}
+		}
+	}
+
+	for {
+		discoveredFeatures := features.Discover(ctx)
+		if len(discoveredFeatures.ToolsNotAvailable) > 0 {
+			stop, err := selectToolProvider(ctx)
+			if err != nil {
+				return err
+			}
+			if stop {
+				break
+			}
+		} else {
+			break
 		}
 	}
 	return nil
@@ -60,4 +75,38 @@ func selectInferenceProvider(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func selectToolProvider(ctx context.Context) (stop bool, err error) {
+	discoveredFeatures := features.Discover(ctx)
+	toolNames := []list.Item{}
+	for _, tool := range discoveredFeatures.ToolsNotAvailable {
+		if tool.Attributes().SupportsSetup() {
+			toolNames = append(toolNames, selector.Item(tool.Attributes().Name()))
+		}
+	}
+	if len(toolNames) == 0 {
+		return true, nil
+	}
+	toolNames = append(toolNames, selector.Item("Terminate setup"))
+	tool, err := selector.Select("Some tools can be setup, please select below the tool you may want to use:", toolNames)
+	if err != nil {
+		return false, err
+	}
+	if tool == "Terminate setup" {
+		return true, nil
+	}
+	log.Infof("tool selected by user: %v", tool)
+
+	for _, notAvailableTool := range discoveredFeatures.ToolsNotAvailable {
+		if notAvailableTool.Attributes().Name() == tool {
+			err = notAvailableTool.InstallHelp()
+			if err != nil {
+				return false, err
+			}
+			break
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -1,0 +1,11 @@
+package system
+
+var provider System = &fallbackSystem{}
+
+type System interface {
+	OpenBrowser(url string) error
+}
+
+func OpenBrowser(url string) error {
+	return provider.OpenBrowser(url)
+}

--- a/pkg/system/system_darwin.go
+++ b/pkg/system/system_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+// +build darwin
+
+package system
+
+import "os/exec"
+
+type darwinSystem struct{}
+
+var _ System = &darwinSystem{}
+
+func (k *darwinSystem) OpenBrowser(url string) error {
+	return exec.Command("open", url).Run()
+}
+
+func init() {
+	provider = &darwinSystem{}
+}

--- a/pkg/system/system_fallback.go
+++ b/pkg/system/system_fallback.go
@@ -1,0 +1,11 @@
+package system
+
+import "errors"
+
+type fallbackSystem struct{}
+
+var _ System = &fallbackSystem{}
+
+func (k *fallbackSystem) OpenBrowser(url string) error {
+	return errors.New("not implemented")
+}

--- a/pkg/system/system_linux.go
+++ b/pkg/system/system_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+// +build linux
+
+package system
+
+import "os/exec"
+
+type linuxSystem struct{}
+
+var _ System = &linuxSystem{}
+
+func (k *linuxSystem) OpenBrowser(url string) error {
+	return exec.Command("xdg-open", url).Run()
+}
+
+func init() {
+	provider = &linuxSystem{}
+}


### PR DESCRIPTION
Adds tools setup to the `ai-cli setup` command, with implementation for GitHub.
The user can:
- open the standard page for creating a personal access token
- copy/paste github token and save it in keyring

I'm working on a follow-up PR to test the setup logic