### PR TITLE
feat: update cursor mcp config file

### DIFF
--- a/pkg/mcp-config/cursor/cursor.go
+++ b/pkg/mcp-config/cursor/cursor.go
@@ -2,25 +2,34 @@ package cursor
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"os"
 	"path"
 	"strings"
 
 	"github.com/adrg/xdg"
 	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
 )
+
+const prefix = "ai-cli-"
 
 type CursorMcpConfigFile struct {
 	McpServers map[string]any `json:"mcpServers"`
 }
 
 type StdioServerConfig struct {
+	Type    string            `json:"type,omitempty"`
 	Command string            `json:"command,omitempty"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
+	EnvFile string            `json:"envFile,omitempty"`
 }
 
 type RemoteServerConfig struct {
-	Url string `json:"url,omitempty"`
+	Type string `json:"type,omitempty"`
+	Url  string `json:"url,omitempty"`
 	/**
 	 * Optional HTTP headers to include with every request to this server (e.g. for authentication).
 	 * The keys are header names and the values are header values.
@@ -35,23 +44,75 @@ func (p *CursorMcpConfig) GetFile() string {
 }
 
 func (p *CursorMcpConfig) GetConfig(tools []api.ToolsProvider) ([]byte, error) {
-	result := CursorMcpConfigFile{
-		McpServers: make(map[string]any),
+	configFile := p.GetFile()
+	var existingConfig *CursorMcpConfigFile
+	if _, err := config.FileSystem.Stat(configFile); err == nil {
+		existingConfig, err = readExistingConfig(configFile)
+		if err != nil {
+			return nil, err
+		}
 	}
+	if existingConfig == nil {
+		existingConfig = &CursorMcpConfigFile{
+			McpServers: make(map[string]any),
+		}
+	}
+	if existingConfig.McpServers == nil {
+		existingConfig.McpServers = make(map[string]any)
+	}
+
+	// Remove existing tools prefixed with our prefix
+	for name := range existingConfig.McpServers {
+		if strings.HasPrefix(name, prefix) {
+			delete(existingConfig.McpServers, name)
+		}
+	}
+
+	// Add our tools with our prefix
 	for _, tool := range tools {
 		mcpSettings := tool.GetMcpSettings()
 		if mcpSettings == nil {
 			continue
 		}
-		if mcpSettings.Type == api.McpTypeStdio {
-			result.McpServers[tool.Attributes().Name()] = StdioServerConfig{
+		switch mcpSettings.Type {
+		case api.McpTypeStdio:
+			existingConfig.McpServers[toolName(tool)] = StdioServerConfig{
+				Type:    mcpSettings.Type.String(),
 				Command: mcpSettings.Command,
 				Args:    mcpSettings.Args,
 				Env:     toEnvMap(mcpSettings.Env),
 			}
+		case api.McpTypeStreamableHttp:
+			existingConfig.McpServers[toolName(tool)] = RemoteServerConfig{
+				Type:    mcpSettings.Type.String(),
+				Url:     mcpSettings.Url,
+				Headers: mcpSettings.Headers,
+			}
+		default:
+			continue
 		}
 	}
-	return json.MarshalIndent(result, "", "  ")
+	return json.MarshalIndent(existingConfig, "", "  ")
+}
+
+func readExistingConfig(configFile string) (*CursorMcpConfigFile, error) {
+	file, err := config.FileSystem.OpenFile(configFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	fileContent, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	var existingConfig CursorMcpConfigFile
+	err = json.Unmarshal(fileContent, &existingConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &existingConfig, nil
 }
 
 func toEnvMap(envArray []string) map[string]string {
@@ -61,4 +122,8 @@ func toEnvMap(envArray []string) map[string]string {
 		result[key] = value
 	}
 	return result
+}
+
+func toolName(tool api.ToolsProvider) string {
+	return fmt.Sprintf("%s%s", prefix, tool.Attributes().Name())
 }

--- a/pkg/mcp-config/cursor/cursor_test.go
+++ b/pkg/mcp-config/cursor/cursor_test.go
@@ -1,10 +1,14 @@
 package cursor
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/adrg/xdg"
 	"github.com/manusa/ai-cli/internal/test"
 	"github.com/manusa/ai-cli/pkg/api"
+	"github.com/manusa/ai-cli/pkg/config"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,7 +25,10 @@ func (p *TestToolsProvider) GetMcpSettings() *api.McpSettings {
 	return p.mcpSettings
 }
 
-func (s *CursorTestSuite) SetupTest() {}
+func (s *CursorTestSuite) SetupTest() {
+	config.FileSystem = afero.NewMemMapFs()
+	xdg.Home = "/path/to/home"
+}
 
 func TestCursor(t *testing.T) {
 	suite.Run(t, new(CursorTestSuite))
@@ -37,8 +44,8 @@ func (s *CursorTestSuite) TestGetConfigEmpty() {
 	})
 }
 
-func (s *CursorTestSuite) TestGetConfigWithTools() {
-	s.Run("GetConfig returns a config with the tools", func() {
+func (s *CursorTestSuite) TestGetConfigWithToolsWhenNoConfigExists() {
+	s.Run("GetConfig returns a config with the tools when no config exists", func() {
 		provider := &CursorMcpConfig{}
 		tools := []api.ToolsProvider{
 			&TestToolsProvider{
@@ -62,6 +69,148 @@ func (s *CursorTestSuite) TestGetConfigWithTools() {
 		}
 		result, err := provider.GetConfig(tools)
 		s.NoError(err)
-		s.JSONEq(string(result), `{ "mcpServers": { "testtool": { "command": "mycmd", "args": ["arg1", "arg2"], "env": { "ENV": "value" } } } }`)
+		s.JSONEq(string(result), `{ "mcpServers": { "ai-cli-testtool": { "type": "stdio", "command": "mycmd", "args": ["arg1", "arg2"], "env": { "ENV": "value" } } } }`)
 	})
+}
+
+func (s *CursorTestSuite) TestGetConfigAddToolsWhenConfigExists() {
+	s.Run("GetConfig returns a config with the tools added when a config exists", func() {
+		err := createFile(config.FileSystem, "/path/to/home/.cursor/mcp.json", `
+{
+	"mcpServers": {
+		"other-tool": {
+			"type": "stdio",
+			"command": "other-tool",
+			"args": [],
+			"env": {
+				"ENV1": "value1"
+			}
+		}
+	}
+}`)
+		s.NoError(err)
+		provider := &CursorMcpConfig{}
+		tools := []api.ToolsProvider{
+			&TestToolsProvider{
+				ToolsProvider: test.ToolsProvider{
+					BasicToolsProvider: api.BasicToolsProvider{
+						BasicToolsAttributes: api.BasicToolsAttributes{
+							BasicFeatureAttributes: api.BasicFeatureAttributes{
+								FeatureName:        "testtool",
+								FeatureDescription: "Test Tool",
+							},
+						},
+					},
+				},
+				mcpSettings: &api.McpSettings{
+					Type:    api.McpTypeStdio,
+					Command: "mycmd",
+					Args:    []string{"arg1", "arg2"},
+					Env:     []string{"ENV=value"},
+				},
+			},
+		}
+		result, err := provider.GetConfig(tools)
+		s.NoError(err)
+		s.JSONEq(string(result), `{ "mcpServers": { "other-tool": { "type": "stdio", "command": "other-tool", "args": [], "env": { "ENV1": "value1" } }, "ai-cli-testtool": { "type": "stdio", "command": "mycmd", "args": ["arg1", "arg2"], "env": { "ENV": "value" } } } }`)
+	})
+}
+
+func (s *CursorTestSuite) TestGetConfigUpdateToolsWhenConfigExists() {
+	s.Run("GetConfig returns a config with the tools updated when a config exists", func() {
+		err := createFile(config.FileSystem, "/path/to/home/.cursor/mcp.json", `
+{
+	"mcpServers": {
+		"other-tool": {
+			"type": "stdio",
+			"command": "other-tool",
+			"args": [],
+			"env": {
+				"ENV1": "value1"
+			}
+		},
+		"ai-cli-testtool": {
+			"type": "stdio",
+			"command": "my-previous-cmd",
+			"args": ["arg1", "arg2", "arg3"],
+			"env": {
+				"ENV": "previous-value"
+			}
+		}
+	}
+}`)
+		s.NoError(err)
+		provider := &CursorMcpConfig{}
+		tools := []api.ToolsProvider{
+			&TestToolsProvider{
+				ToolsProvider: test.ToolsProvider{
+					BasicToolsProvider: api.BasicToolsProvider{
+						BasicToolsAttributes: api.BasicToolsAttributes{
+							BasicFeatureAttributes: api.BasicFeatureAttributes{
+								FeatureName:        "testtool",
+								FeatureDescription: "Test Tool",
+							},
+						},
+					},
+				},
+				mcpSettings: &api.McpSettings{
+					Type:    api.McpTypeStdio,
+					Command: "mycmd",
+					Args:    []string{"arg1", "arg2"},
+					Env:     []string{"ENV=value"},
+				},
+			},
+		}
+		result, err := provider.GetConfig(tools)
+		s.NoError(err)
+		s.JSONEq(string(result), `{ "mcpServers": { "other-tool": { "type": "stdio", "command": "other-tool", "args": [], "env": { "ENV1": "value1" } }, "ai-cli-testtool": { "type": "stdio", "command": "mycmd", "args": ["arg1", "arg2"], "env": { "ENV": "value" } } } }`)
+	})
+}
+
+func (s *CursorTestSuite) TestGetConfigDeleteToolsWhenConfigExists() {
+	s.Run("GetConfig returns a config with the tools deleted when a config exists", func() {
+		err := createFile(config.FileSystem, "/path/to/home/.cursor/mcp.json", `
+{
+	"mcpServers": {
+		"other-tool": {
+			"type": "stdio",
+			"command": "other-tool",
+			"args": [],
+			"env": {
+				"ENV1": "value1"
+			}
+		},
+		"ai-cli-testtool": {
+			"type": "stdio",
+			"command": "my-previous-cmd",
+			"args": ["arg1", "arg2", "arg3"],
+			"env": {
+				"ENV": "previous-value"
+			}
+		}
+	}
+}`)
+		s.NoError(err)
+		provider := &CursorMcpConfig{}
+		tools := []api.ToolsProvider{}
+		result, err := provider.GetConfig(tools)
+		s.NoError(err)
+		s.JSONEq(string(result), `{ "mcpServers": { "other-tool": { "type": "stdio", "command": "other-tool", "args": [], "env": { "ENV1": "value1" } } } }`)
+	})
+}
+
+func createFile(fs afero.Fs, path string, content string) error {
+	err := fs.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return err
+	}
+	file, err := fs.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	_, err = file.Write([]byte(content))
+	return err
 }

--- a/pkg/mcp-config/mcp-config.go
+++ b/pkg/mcp-config/mcp-config.go
@@ -2,7 +2,6 @@ package mcpconfig
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/manusa/ai-cli/pkg/api"
@@ -15,30 +14,29 @@ func Save(provider api.MCPConfig, tools []api.ToolsProvider) error {
 		return err
 	}
 	configFile := provider.GetFile()
+	exists := false
 	if _, err := config.FileSystem.Stat(configFile); err == nil {
-		// file exists, output config to stdout
-		// and message to stderr
-		fmt.Fprintf(os.Stderr, "MCP config file %s already exists, outputting config to stdout\n", configFile)
-		_, err := fmt.Println(string(content))
+		exists = true
+	}
+	err = config.FileSystem.MkdirAll(filepath.Dir(configFile), 0755)
+	if err != nil {
 		return err
-	} else {
-		// file does not exist, create it
-		err = config.FileSystem.MkdirAll(filepath.Dir(configFile), 0755)
-		if err != nil {
-			return err
-		}
-		file, err := config.FileSystem.Create(configFile)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			_ = file.Close()
-		}()
-		_, err = file.Write(content)
-		if err != nil {
-			return err
-		}
+	}
+	file, err := config.FileSystem.Create(configFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	_, err = file.Write(content)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		fmt.Printf("MCP config file %s has been created\n", configFile)
+	} else {
+		fmt.Printf("MCP config file %s has been updated\n", configFile)
 	}
 	return nil
 }

--- a/pkg/mcp-config/mcp-config_test.go
+++ b/pkg/mcp-config/mcp-config_test.go
@@ -48,9 +48,9 @@ func (s *McpConfigTestSuite) TestSaveNewFile() {
 	})
 }
 
-func (s *McpConfigTestSuite) TestSaveStdout() {
-	s.Run("Save outputs to stdoutif config file exists", func() {
-		err := createFile(config.FileSystem, "/path/to/config", "content before")
+func (s *McpConfigTestSuite) TestSaveExisting() {
+	s.Run("Save updates the file if an empty config file exists", func() {
+		err := createFile(config.FileSystem, "/path/to/config", "previous content")
 		s.NoError(err)
 		out, errOut, err := captureStdouts(func() error { return Save(&TestProvider{}, nil) })
 		s.NoError(err)
@@ -60,11 +60,12 @@ func (s *McpConfigTestSuite) TestSaveStdout() {
 		content, err := readFile(config.FileSystem, "/path/to/config")
 		s.NoError(err)
 		// content should not have changed
-		s.Equal("content before", string(content))
-		s.Equal("MCP config file /path/to/config already exists, outputting config to stdout\n", errOut)
-		s.Equal("a config\n", out)
+		s.Equal("a config", string(content))
+		s.Equal("MCP config file /path/to/config has been updated\n", out)
+		s.Equal("", errOut)
 	})
 }
+
 func TestMcpConfig(t *testing.T) {
 	suite.Run(t, new(McpConfigTestSuite))
 }


### PR DESCRIPTION
`./ai-cli discover --mcp-config cursor` now always writes the file `$HOME/.cursor/mcp.json`:

- if the file does not exist, it creates it with tools names prefixed with `ai-cli-`
- if the files exists, it does not update the tools not prefixed with `ai-cli-` and adds the tools discovered by ai-cli with this prefix (and removes the ones prefixed with `ai-cli` not anymore discovered by ai-cli) 